### PR TITLE
Add/component/svg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5412,11 +5412,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -7874,7 +7876,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9071,6 +9075,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9724,11 +9730,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -9926,35 +9934,18 @@
         "node": ">=10"
       }
     },
-    "node_modules/normalize-package-data/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.5.1",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/normalize-package-data/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -12265,7 +12256,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13730,6 +13723,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/plugin/inc/Plugin.php
+++ b/plugin/inc/Plugin.php
@@ -24,6 +24,7 @@ class Plugin {
 	 * @param Lazysizes\Lazysizes               $lazysizes The lazysizes component.
 	 * @param Lightbox\Lightbox                 $lightbox The lightbox component.
 	 * @param Settings\Settings                 $settings The settings component.
+	 * @param SVG\SVG                           $svg The svg component.
 	 */
 	public function __construct(
 		private i18n\I18N $i18n,
@@ -32,6 +33,7 @@ class Plugin {
 		private Lazysizes\Lazysizes $lazysizes,
 		private Lightbox\Lightbox $lightbox,
 		private Settings\Settings $settings,
+		private SVG\SVG $svg,
 	) {
 	}
 
@@ -97,5 +99,12 @@ class Plugin {
 	 */
 	public function container() {
 		return plugin_container();
+	}
+
+	/**
+	 * Get the SVG component.
+	 */
+	public function svg() {
+		return $this->svg;
 	}
 }

--- a/plugin/inc/SVG/Icon.php
+++ b/plugin/inc/SVG/Icon.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * The class to represent an Icon Object.
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\SVG;
+
+/**
+ * A single Icon.
+ */
+class Icon implements \JsonSerializable {
+	/**
+	 * The path of the icon relative to the theme.
+	 *
+	 * @var string
+	 */
+	protected string $path;
+
+	/**
+	 * Wether to expose the Icon to the REST API or not.
+	 *
+	 * @var boolean
+	 */
+	protected bool $show_in_rest;
+
+	/**
+	 * The slug of the icon.
+	 *
+	 * @var string
+	 */
+	protected string $slug;
+
+	/**
+	 * The readable title of an icon.
+	 *
+	 * @var string
+	 */
+	protected string $title;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param string $path         The path of the icon relative to the theme.
+	 * @param string $slug         The slug of the icon.
+	 * @param string $title        The readable title of an icon.
+	 * @param bool   $show_in_rest Wether to expose the Icon to the REST api or not.
+	 * @return void
+	 */
+	public function __construct( $path = null, $slug = null, $title = null, $show_in_rest = true ) {
+		if ( $path && ! empty( $path ) ) {
+			$this->set_path( $path );
+		}
+		if ( $slug && ! empty( $slug ) ) {
+			$this->set_slug( $slug );
+		}
+		if ( $title && ! empty( $title ) ) {
+			$this->set_title( $title );
+		}
+
+		$this->set_show_in_rest( $show_in_rest );
+	}
+
+	/**
+	 * Return the icon's path.
+	 *
+	 * @return string The icon's path.
+	 */
+	public function get_path() {
+		return $this->path;
+	}
+
+	/**
+	 * Return the icon's slug.
+	 *
+	 * @return string The icon's slug.
+	 */
+	public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Return the icon's title.
+	 *
+	 * @return string The icon's title.
+	 */
+	public function get_title() {
+		return $this->title;
+	}
+
+	/**
+	 * Return if the Icon can be exposed to the REST API.
+	 *
+	 * @return bool True if exposable, false otherwise.
+	 */
+	public function show_in_rest() {
+		return $this->show_in_rest;
+	}
+
+	/**
+	 * Set the icon's path.
+	 *
+	 * @param string $path The path to set.
+	 * @return void.
+	 */
+	public function set_path( $path ) {
+		if ( ! empty( $path ) ) {
+			$this->path = $path;
+		}
+	}
+
+	/**
+	 * Set the icon's slug.
+	 *
+	 * @param string $slug The slug to set.
+	 * @return void.
+	 */
+	public function set_slug( $slug ) {
+		if ( ! empty( $slug ) ) {
+			$this->slug = $slug;
+		}
+	}
+
+	/**
+	 * Set the icon's title.
+	 *
+	 * @param string $title The title to set.
+	 * @return void.
+	 */
+	public function set_title( $title ) {
+		if ( ! empty( $title ) ) {
+			$this->title = $title;
+		}
+	}
+
+	/**
+	 * Set if the Icon can be exposed to the REST API.
+	 *
+	 * @param bool $show_in_rest True if exposable, false otherwise.
+	 * @return void.
+	 */
+	public function set_show_in_rest( $show_in_rest ) {
+		if ( is_bool( $show_in_rest ) ) {
+			$this->show_in_rest = $show_in_rest;
+		}
+	}
+
+	/**
+	 * Serializes the object to a value that can be serialized natively by wp_|json_encode().
+	 *
+	 * @param array $fields The fields to return.
+	 *
+	 * @return mixed The serialized object.
+	 */
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() : array {
+		$resp = array();
+		// Filter for fields.
+		// E.g. REST shouldn't expose 'path'.
+		foreach ( array( 'path', 'slug', 'title' ) as $field ) {
+			if ( is_callable( array( $this, "get_{$field}" ) ) ) {
+				$callback       = "get_{$field}";
+				$resp[ $field ] = $this->$callback();
+			}
+		}
+		return $resp;
+	}
+}

--- a/plugin/inc/SVG/Icon.php
+++ b/plugin/inc/SVG/Icon.php
@@ -149,8 +149,6 @@ class Icon implements \JsonSerializable {
 	/**
 	 * Serializes the object to a value that can be serialized natively by wp_|json_encode().
 	 *
-	 * @param array $fields The fields to return.
-	 *
 	 * @return mixed The serialized object.
 	 */
 	#[\ReturnTypeWillChange]

--- a/plugin/inc/SVG/Icon_Library.php
+++ b/plugin/inc/SVG/Icon_Library.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * The class to represent the theme's icon library.
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\SVG;
+
+/**
+ * Icon Library Class.
+ */
+class Icon_Library {
+	/**
+	 * The single icons from our icon library.
+	 *
+	 * @var Icon[] The icon object.
+	 */
+	protected $icons = array();
+
+	/**
+	 * Check if an icon to a given slug is registered in our lib.
+	 *
+	 * @param  string $slug The icon's slug.
+	 * @return boolean      True if the item exists, false otherwise.
+	 */
+	public function exists( $slug ) {
+		$icons = $this->get_icons();
+		return isset( $icons[ $slug ] );
+	}
+
+	/**
+	 * Get the path of an icon by given slug.
+	 *
+	 * @param  string $slug The icon's slug.
+	 * @return mixed        The icon's slug if it exists, null otherwise.
+	 */
+	public function get_path( $slug ) {
+		if ( $this->exists( $slug ) ) {
+			$icon = $this->get_icon( $slug );
+			return $icon->get_path();
+		}
+		return null;
+	}
+
+	/**
+	 * Get all registered icons.
+	 *
+	 * @return array Array of icons.
+	 */
+	public function get_icons() {
+		return $this->icons;
+	}
+
+	/**
+	 * Get a single icon by slug.
+	 *
+	 * @param  string $slug The icon's slug.
+	 * @return mixed        The requests icon if it exists, null otherwise.
+	 */
+	public function get_icon( string $slug ) {
+		if ( $this->exists( $slug ) ) {
+			return $this->icons[ $slug ];
+		}
+		return null;
+	}
+
+	/**
+	 * Set a given collection of icons.
+	 *
+	 * @param  Icon[] $icons The icon's to set.
+	 * @return void
+	 */
+	public function set_icons( $icons = array() ) {
+		$this->icons = array();
+		$this->add_icons( $icons );
+	}
+
+	/**
+	 * Add a given collection of icons.
+	 *
+	 * @param  Icon[] $icons The icon's to add.
+	 * @return void
+	 */
+	public function add_icons( $icons = array() ) {
+		foreach ( $icons as $icon ) {
+			$this->add_icon( $icon );
+		}
+	}
+
+	/**
+	 * Add a single icon.
+	 *
+	 * @param  Icon $icon The icon to add.
+	 * @return void
+	 */
+	public function add_icon( Icon $icon ) {
+		$this->icons[ $icon->get_slug() ] = $icon;
+	}
+}

--- a/plugin/inc/SVG/README.md
+++ b/plugin/inc/SVG/README.md
@@ -1,0 +1,61 @@
+# SVG Component
+The SVG component is intended to ease the handling of SVG images in the WordPress
+enviroment. It provides two exposed plugin functions, that read, parse and output
+the SVG code in the desired manner.
+
+## Relative Paths
+The paths passed to the functions are relative paths based on the active theme or
+current plugin. The component first looks into the theme folder to find the file
+and then in the plugin folder.
+
+
+## Functions
+
+### get_svg( (sting) $path, (array) $arguments )
+The `get_svg()` function returns the SVG DOM for the file in the given path.
+
+#### Arguments
+* `(string) $path` - The given path relative to the current theme or plugin.
+* `(array) $arguments` - An array of arguments to modify the behavior of the function.
+  - `(array) $attributes` - An array of HTML attributes applied to the returned SVG tag. Valid array keys are 'class', 'id', 'width', 'height', 'fill'.
+  - `(string) $return_type` - The desired return type for the SVG DOM. Valid inputs are 'tag' and 'base64'. Defaults to 'tag'.
+
+#### Returns
+`(string)` The svg HTML dom in the type defined in `return_type`.
+
+### get_admin_menu_icon( (string) $path )
+A wrapper for the `get_svg()` function that provides the fitting arguments to use
+SVGs in admin menu items.
+
+#### Arguments
+* `(string) $path` - The given path relative to the current theme or plugin.
+
+#### Returns
+`(string)` The base64 encoded svg HTML dom.
+
+## Example
+### Base SVG
+```
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 355.55 425.2">
+  <path d="M355.55 0h-64.07L115.36 425.2h64.07zM240.19 0h-64.07L0 425.2h64.07z"/>
+</svg>
+```
+
+### Code
+```
+$arguments = array(
+	'attributes' => array(
+		'fill'  => '#26b8ff',
+		'class' => 'slashes-svg',
+		'id'    => 'slashes',
+	),
+);
+
+return plugin()->svg()->get_svg( 'img/icons/slashes.svg', $arguments );
+```
+### Returns
+```
+<svg xmlns="http://www.w3.org/2000/svg" class="slashes-svg" fill="#26b8ff" id="slashes" viewBox="0 0 355.55 425.2">
+  <path d="M355.55 0h-64.07L115.36 425.2h64.07zM240.19 0h-64.07L0 425.2h64.07z"></path>
+</svg>
+```

--- a/plugin/inc/SVG/REST.php
+++ b/plugin/inc/SVG/REST.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * The SVG REST class.
+ *
+ * This file defines the `REST` class, which registers and manages custom REST API endpoints
+ * for svg icons.
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\REST;
+
+use WP_REST_Server;
+
+use function WpMunich\basics\plugin\plugin;
+use function add_action;
+use function apply_filters;
+use function esc_attr;
+use function register_rest_route;
+use function rest_ensure_response;
+use function wp_parse_args;
+
+/**
+ * REST
+ *
+ * A class to register and manage svg/icon custom REST API endpoints.
+ */
+class REST {
+
+	/**
+	 * The namespace for REST endpoints in this component.
+	 *
+	 * @var string
+	 */
+	private $rest_namespace = 'lhbasics/v1'; // Could be outsourced to a "blank" REST component or similar.
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_actions() {
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_filters() {}
+
+	/**
+	 * Register custom REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		// Route to retrieve all icons.
+		register_rest_route(
+			$this->rest_namespace,
+			'icons',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'rest_get_icons' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		// Route to retrieve a single icon by slug.
+		register_rest_route(
+			$this->rest_namespace,
+			'icon(?:/(?<slug>[a-z0-9-]+))?',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'rest_get_icon' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'slug' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Retrieve all icons from the icon library via REST.
+	 *
+	 * Returns a filtered list of icons available in the plugin's icon library. This includes
+	 * options to restrict results based on specific icon slugs provided as a comma-separated
+	 * parameter in the request.
+	 *
+	 * @param  WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response containing icon data.
+	 */
+	public function rest_get_icons( $request ) {
+		$slugs     = $request->get_param( 'slugs' );
+		$lib_icons = plugin()->svg()->get_icon_library()->get_icons();
+		$res_icons = array();
+
+		// Process the `slugs` parameter, if provided.
+		if ( $slugs && ! empty( $slugs ) ) {
+			$slugs = explode( ',', $slugs );
+		}
+
+		// Loop through icons and filter based on visibility in REST API.
+		foreach ( $lib_icons as $icon ) {
+			if ( $icon->show_in_rest() ) {
+				if ( is_array( $slugs ) && ! in_array( $icon->get_slug(), $slugs, true ) ) {
+					continue;
+				}
+
+				$res_icons[] = wp_parse_args(
+					$icon->jsonSerialize( array( 'slug', 'title' ) ),
+					array(
+						'svg' => plugin()->svg()->get_svg( $icon->get_slug() ),
+					)
+				);
+			}
+		}
+		return rest_ensure_response( $res_icons );
+	}
+
+	/**
+	 * Retrieve a single icon by slug via REST.
+	 *
+	 * Accepts a `slug` parameter to identify the icon, and optional parameters for SVG attributes.
+	 * This enables API clients to specify icon attributes dynamically.
+	 *
+	 * @param  WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response containing the requested icon data.
+	 */
+	public function rest_get_icon( $request ) {
+		$slug = $request->get_param( 'slug' );
+		$path = $request->get_param( 'path' );
+		$args = $this->get_args_from_request( $request );
+
+		$svg = plugin()->svg()->get_svg( $slug );
+
+		// Fallback to using `path` parameter if slug is not found.
+		if ( ! $svg && $path && ! empty( $path ) ) {
+			$svg = plugin()->svg()->get_svg( $path );
+		}
+
+		$icon = $slug && $svg ? plugin()->svg()->get_icon_library()->get_icon( $slug )->jsonSerialize( array( 'slug', 'title' ) ) : array();
+
+		$response = apply_filters(
+			'basicsp_rest_get_svg_response',
+			wp_parse_args(
+				$icon,
+				array( 'svg' => $svg )
+			),
+			$slug,
+			$args
+		);
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Helper function to map request parameters to SVG attributes.
+	 *
+	 * Extracts relevant attributes from the request and maps them to a format suitable
+	 * for the plugin's `get_svg` function, supporting dynamic SVG generation.
+	 *
+	 * @param WP_REST_Request $request The request to check for params.
+	 * @return array The $args array for `get_svg`.
+	 */
+	private function get_args_from_request( $request ) {
+		$args = array();
+		$attr = array();
+
+		if ( isset( $request['class'] ) ) {
+			$attr['class'] = esc_attr( $request['class'] );
+		}
+		if ( isset( $request['id'] ) ) {
+			$attr['id'] = esc_attr( $request['id'] );
+		}
+		if ( isset( $request['width'] ) ) {
+			$attr['width'] = esc_attr( $request['width'] );
+		}
+		if ( isset( $request['height'] ) ) {
+			$attr['height'] = esc_attr( $request['height'] );
+		}
+		if ( isset( $request['fill'] ) ) {
+			$attr['fill'] = esc_attr( $request['fill'] );
+		}
+
+		// Add attributes to $args if any were set.
+		if ( count( $attr ) ) {
+			$args['attributes'] = $attr;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the current REST namespace.
+	 *
+	 * Returns the namespace used for this component’s REST routes.
+	 *
+	 * @return string The REST namespace.
+	 */
+	public function get_namespace() {
+		return $this->rest_namespace;
+	}
+}

--- a/plugin/inc/SVG/REST.php
+++ b/plugin/inc/SVG/REST.php
@@ -8,7 +8,7 @@
  * @package lhbasicsp
  */
 
-namespace WpMunich\basics\plugin\REST;
+namespace WpMunich\basics\plugin\SVG;
 
 use WP_REST_Server;
 
@@ -33,6 +33,14 @@ class REST {
 	 * @var string
 	 */
 	private $rest_namespace = 'lhbasics/v1'; // Could be outsourced to a "blank" REST component or similar.
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->add_actions();
+		$this->add_filters();
+	}
 
 	/**
 	 * {@inheritDoc}

--- a/plugin/inc/SVG/SVG.php
+++ b/plugin/inc/SVG/SVG.php
@@ -27,6 +27,8 @@ class SVG extends Plugin_Component {
 
 	/**
 	 * REST controller.
+	 *
+	 * @var REST
 	 */
 	private $rest_controller;
 

--- a/plugin/inc/SVG/SVG.php
+++ b/plugin/inc/SVG/SVG.php
@@ -26,6 +26,19 @@ class SVG extends Plugin_Component {
 	private $icon_library;
 
 	/**
+	 * REST controller.
+	 */
+	private $rest_controller;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->rest_controller = new REST();
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	protected function add_actions() {}

--- a/plugin/inc/SVG/SVG.php
+++ b/plugin/inc/SVG/SVG.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Holds the SVG class
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\SVG;
+
+use WpMunich\basics\plugin\Plugin_Component;
+
+use function WpMunich\basics\plugin\plugin;
+use function add_filter;
+use function get_template_directory;
+
+/**
+ * The Component
+ */
+class SVG extends Plugin_Component {
+
+	/**
+	 * Library of icons supported by the theme.
+	 *
+	 * @var Icon_Library
+	 */
+	private $icon_library;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_actions() {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_filters() {
+		add_filter( 'wp_kses_allowed_html', array( $this, 'allowed_html' ), 10, 2 );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function must_run() {}
+
+	/**
+	 * Returns the supported block library.
+	 *
+	 * @return Icon_library The icon library
+	 */
+	public function get_icon_library() {
+		if ( ! $this->icon_library instanceof Icon_Library ) {
+			$base_path = plugin()->get_plugin_path();
+
+			$this->icon_library = new Icon_Library();
+			$this->icon_library->set_icons(
+				array(
+					new Icon(
+						$base_path . 'img/icons/slashes.svg',
+						'slashes',
+						__( 'Slashes', 'basicsp' ),
+					),
+					new Icon(
+						$base_path . 'img/icons/chevron--left.svg',
+						'chevron--left',
+						__( 'Chevron Left', 'basicsp' ),
+					),
+					new Icon(
+						$base_path . 'img/icons/chevron--right.svg',
+						'chevron--right',
+						__( 'Chevron Right', 'basicsp' ),
+					),
+				)
+			);
+		}
+		return $this->icon_library;
+	}
+
+	/**
+	 * Get an SVG from the theme or plugin folder.
+	 *
+	 * @param string $pointer The SVG slug or path to be loaded. The path is relative to the theme or plugin folder.
+	 *                        It first checks if the SVG is in the theme folder and falls back to the plugin folder.
+	 * @param array  $args    An array of arguments for the SVG class. See the WP_SVG_Image class constructor for more details.
+	 *
+	 * @return string The SVG code.
+	 */
+	public function get_svg( string $pointer, $args = array() ) {
+		$final_path = get_template_directory() . $pointer;
+		$icon_lib   = $this->get_icon_library();
+
+		switch ( $pointer ) {
+			case ( $icon_lib->exists( $pointer ) ):
+				$final_path = $icon_lib->get_path( $pointer );
+				break;
+			case ( file_exists( get_template_directory() . $pointer ) ):
+				$final_path = get_template_directory() . $pointer;
+				break;
+			case ( file_exists( plugin()->get_plugin_path() . $pointer ) ):
+				$final_path = plugin()->get_plugin_path() . $pointer;
+				break;
+			default:
+				return false;
+				break;
+		}
+
+		if ( ! file_exists( $final_path ) ) {
+			return false;
+		}
+
+		if ( ! in_array( mime_content_type( $final_path ), array( 'image/svg', 'image/svg+xml' ), true ) ) {
+			return false;
+		}
+
+		$args['svg_path'] = $final_path;
+
+		$svg = new WPM_Svg_Image( $args );
+
+		return $svg->render();
+	}
+
+	/**
+	 * Get an SVG icon for use in WP Admin Menus.
+	 *
+	 * @param  string $path The relative path of the image to the plugin / theme root.
+	 *
+	 * @return string       The base64 encoded svg.
+	 */
+	public function get_admin_menu_icon( $path ) {
+		$args = array(
+			'return_type' => 'base64',
+			'attributes'  => array(
+				'fill'   => '#a0a5aa',
+				'width'  => '20',
+				'height' => '20',
+			),
+		);
+
+		return $this->get_svg( $path, $args );
+	}
+
+	/**
+	 * Adds allowed HTML tags to the allowed tags array.
+	 *
+	 * @param array  $allowed_tags The allowed tags.
+	 * @param string $context The context.
+	 *
+	 * @return array The allowed tags.
+	 */
+	public function allowed_html( $allowed_tags, $context ) {
+		$allowed_tags['svg'] = array(
+			'class'                                => true,
+			'xmlns'                                => true,
+			'width'                                => true,
+			'height'                               => true,
+			'viewbox'                              => true,
+			'role'                                 => true,
+			'preserveaspectratio'                  => true,
+			'preserveaspectratio.align'            => true,
+			'preserveaspectratio.meetorslice'      => true,
+			'preserveaspectratio.slice'            => true,
+			'preserveaspectratio.slice.fill'       => true,
+			'preserveaspectratio.slice.fill.meet'  => true,
+			'preserveaspectratio.slice.fill.slice' => true,
+			'preserveaspectratio.slice.meet'       => true,
+			'preserveaspectratio.x'                => true,
+			'preserveaspectratio.y'                => true,
+			'preserveaspectratio.align'            => true,
+			'preserveaspectratio.meetorslice'      => true,
+			'preserveaspectratio.slice'            => true,
+			'preserveaspectratio.slice.fill'       => true,
+			'preserveaspectratio.slice.fill.meet'  => true,
+			'preserveaspectratio.slice.fill.slice' => true,
+			'preserveaspectratio.slice.meet'       => true,
+			'preserveaspectratio.x'                => true,
+			'preserveaspectratio.y'                => true,
+			'preserveaspectratio.align'            => true,
+			'preserveaspectratio.meetorslice'      => true,
+			'preserveaspectratio.slice'            => true,
+			'preserveaspectratio.slice.fill'       => true,
+			'preserveaspectratio.slice.fill.meet'  => true,
+		);
+
+		$allowed_tags['path'] = array(
+			'd'                 => true,
+			'fill'              => true,
+			'fill-rule'         => true,
+			'fill-opacity'      => true,
+			'stroke'            => true,
+			'stroke-width'      => true,
+			'stroke-linecap'    => true,
+			'stroke-linejoin'   => true,
+			'stroke-miterlimit' => true,
+			'stroke-dasharray'  => true,
+			'stroke-dashoffset' => true,
+			'stroke-opacity'    => true,
+		);
+
+		$allowed_tags['g'] = array(
+			'fill'              => true,
+			'fill-rule'         => true,
+			'fill-opacity'      => true,
+			'stroke'            => true,
+			'stroke-width'      => true,
+			'stroke-linecap'    => true,
+			'stroke-linejoin'   => true,
+			'stroke-miterlimit' => true,
+			'stroke-dasharray'  => true,
+			'stroke-dashoffset' => true,
+			'stroke-opacity'    => true,
+		);
+
+		$allowed_tags['circle'] = array(
+			'cx'             => true,
+			'cy'             => true,
+			'r'              => true,
+			'fill'           => true,
+			'fill-opacity'   => true,
+			'stroke'         => true,
+			'stroke-width'   => true,
+			'stroke-opacity' => true,
+		);
+
+		$allowed_tags['animate'] = array(
+			'attributename' => true,
+			'begin'         => true,
+			'dur'           => true,
+			'end'           => true,
+			'values'        => true,
+			'calcmode'      => true,
+			'repeatcount'   => true,
+		);
+
+		return $allowed_tags;
+	}
+}

--- a/plugin/inc/SVG/WPM_Svg_Image.php
+++ b/plugin/inc/SVG/WPM_Svg_Image.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * The class that holds one svg image.
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\SVG;
+use DOMDocument;
+use function wp_parse_args;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that handles one svg image.
+ */
+class WPM_Svg_Image {
+
+	/**
+	 * An array of allowed svg attributes.
+	 *
+	 * @var array
+	 */
+	private $allowed_attributes = array( 'class', 'id', 'width', 'height', 'fill', 'role' );
+
+	/**
+	 * An array of html attributes that are applied to the svg tag.
+	 *
+	 * @var array
+	 */
+	private $attributes = array();
+
+	/**
+	 * The DOMDocument representation of the SVG.
+	 *
+	 * @var DOMDocument
+	 */
+	private $dom_document;
+
+	/**
+	 * The return type for the render function.
+	 *
+	 * @var string
+	 */
+	private $return_type = 'tag';
+
+	/**
+	 * The SVG DOMElement.
+	 *
+	 * @var DOMElement
+	 */
+	private $svg;
+
+	/**
+	 * The class constructor.
+	 *
+	 * @param array $args An array of arguments for the SVG class.
+	 *                    [
+	 *                      'svg_path'    => (string) The absolute path to the svg image file.
+	 *                      'attributes'  => (array) An array of HTML attributes that are applied to the SVG tag.
+	 *                      'return_type' => (string) Can be one of 'tag', 'base64'. Defaults to 'tag'.
+	 *                    ].
+	 */
+	public function __construct( $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'svg_path'    => false,
+				'attributes'  => array(),
+				'return_type' => 'tag',
+			)
+		);
+
+		$this->attributes  = $this->parse_attributes( $args['attributes'] );
+		$this->return_type = $args['return_type'];
+
+		if ( $args['svg_path'] ) {
+			$this->load( $args['svg_path'] );
+		}
+	}
+
+	/**
+	 * Load the svg and store it as a DOMDocument.
+	 *
+	 * @param  string $svg_path The absolute path to the SVG.
+	 *
+	 * @return boolean          True on success, false on failure
+	 */
+	public function load( $svg_path ) {
+		if ( ! file_exists( $svg_path ) ) {
+			return false;
+		}
+
+		if ( ! in_array( mime_content_type( $svg_path ), array( 'image/svg', 'image/svg+xml' ), true ) ) {
+			return false;
+		}
+
+		$this->dom_document = new DOMDocument();
+		$this->dom_document->loadXML( file_get_contents( $svg_path ) );
+		$this->svg = $this->dom_document->getElementsByTagName( 'svg' )->item( 0 );
+
+		return true;
+	}
+
+	/**
+	 * Render the SVG tag.
+	 *
+	 * @return string The SVG HTML tag.
+	 */
+	public function render() {
+		if ( ! $this->svg instanceof \DOMElement ) {
+			return false;
+		}
+
+		$this->apply_attributes();
+		$html = $this->svg->C14N();
+
+		if ( $this->return_type === 'base64' ) {
+			return 'data:image/svg+xml;base64,' . base64_encode( $html );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Apply the parsed attributes to the SVG.
+	 *
+	 * @return void
+	 */
+	private function apply_attributes() {
+		foreach ( $this->attributes as $key => $value ) {
+			$this->svg->setAttribute( $key, $value );
+		}
+	}
+
+	/**
+	 * Parse attributes, so only valid and allowed attributes get applied.
+	 *
+	 * @param  array $attributes An array of HTML attributes.
+	 *
+	 * @return array             A parsed array of HTML attributes.
+	 */
+	private function parse_attributes( $attributes ) {
+		$allowed_attributes = apply_filters( 'wpm_svg_allowed_attributes', $this->allowed_attributes );
+		$parsed_attributes  = array();
+		foreach ( $attributes as $key => $value ) {
+			if ( in_array( $key, $allowed_attributes, true ) ) {
+				$parsed_attributes[ $key ] = esc_attr( $value );
+			}
+		}
+
+		return $parsed_attributes;
+	}
+}


### PR DESCRIPTION
moves the SVG component of the wp-project-boilerplate to this plugin.

**NOTE:** This is for the SVG and REST component only! The "gutenberg component"/"Icon Select" should stay at the boilerplate. Otherwise we'd have to work out a strategy how to expose them via basics to be used in <project>-plugin.

As for the REST component:
I moved it to /SVG/REST.php instead of creating an generic REST component.
We may want to rename this to "REST_Controller" or "Icon_REST" or similar.
No interface (yet?) as it's the only REST controller used by now. However: "mocks" the Plugin_Component.

For a first/quick test: Set pretty permalinks and visit `/wp-json/lhbasics/v1/icons`
