### PR TITLE
upd/svg/add-filter/svg-icon-library-icons

### DIFF
--- a/plugin/inc/SVG/README.md
+++ b/plugin/inc/SVG/README.md
@@ -9,6 +9,55 @@ current plugin. The component first looks into the theme folder to find the file
 and then in the plugin folder.
 
 
+## Filters
+
+### `lhagentur_svg_icon_library_icons`
+Filters the array of `<Icon>`s passed to the `<Icon_Library>`.
+
+#### Parameters
+* `(array) $icons` - An array of `<Icon>`s.
+
+#### Returns
+* `(array) $icons` - The updated / created array of `<Icon>`s
+
+#### Example
+```PHP
+use WpMunich\basics\plugin\SVG\Icon;
+
+# ...
+add_filter( 'lhagentur_svg_icons_library_icons', 'my_svg_icons_library_icons' );
+
+# ...
+function my_svg_icons_library_icons( array $icons ): array {
+	// If there's some case in which no icons should be registered.
+	if (some_other_condition) {
+		return $icons;
+	}
+
+	$img_path = 'my/img/path/';
+	$my_icons = array(
+		new Icon(
+			$icon_path . 'icons/my-icon.svg',
+			'my-icon--slug',
+			__( 'My Icon Label', 'textdomain' )
+		),
+		# ...
+	);
+
+	// If you want to add icons.
+	if ( some_condition ) {
+		return array_merge(
+			$icons,
+			$my_icons
+		);
+	}
+
+	// If you want to override icons.
+	return $my_icons;
+}
+```
+
+
 ## Functions
 
 ### get_svg( (sting) $path, (array) $arguments )

--- a/plugin/inc/SVG/SVG.php
+++ b/plugin/inc/SVG/SVG.php
@@ -65,9 +65,8 @@ class SVG extends Plugin_Component {
 	public function get_icon_library() {
 		if ( ! $this->icon_library instanceof Icon_Library ) {
 			$base_path = plugin()->get_plugin_path();
-
-			$this->icon_library = new Icon_Library();
-			$this->icon_library->set_icons(
+			$icons     = apply_filters(
+				'lhagentur_svg_icon_library_icons',
 				array(
 					new Icon(
 						$base_path . 'img/icons/slashes.svg',
@@ -86,6 +85,9 @@ class SVG extends Plugin_Component {
 					),
 				)
 			);
+
+			$this->icon_library = new Icon_Library();
+			$this->icon_library->set_icons( $icons );
 		}
 		return $this->icon_library;
 	}


### PR DESCRIPTION
This PR adds a filter for the array of icons passed to the icon library. This is needed so themes / plugins can actually register own sets of icons.

Also updated the README to contain docs for the filter as well as an usage example.