### PR TITLE
re-add image attributes to lazysize images

### DIFF
--- a/plugin/inc/Lazysizes/Lazysizes.php
+++ b/plugin/inc/Lazysizes/Lazysizes.php
@@ -272,6 +272,13 @@ class Lazysizes extends Plugin_Component {
 		}
 
 		/**
+		 * Re-add attributes from the original image to the new image.
+		 */
+		foreach ( $block_image->attributes as $attribute ) {
+			$new_image_html = str_replace( '<img', '<img ' . $attribute->name . '="' . $attribute->value . '"', $new_image_html );
+		}
+
+		/**
 		 * Load the new image tag into the DOMDocument.
 		 */
 		$img_doc->loadHTML( '<?xml encoding="utf-8" ?>' . $new_image_html );

--- a/plugin/inc/Lazysizes/Lazysizes.php
+++ b/plugin/inc/Lazysizes/Lazysizes.php
@@ -262,20 +262,17 @@ class Lazysizes extends Plugin_Component {
 		/**
 		 * Create a new image element.
 		 */
-		$new_image_html = wp_get_attachment_image( $block['attrs']['id'] ?? null, $block['attrs']['sizeSlug'] ?? 'full' );
+		$old_image_attrs = array();
+		foreach ( $block_image->attributes as $attribute ) {
+			$old_image_attrs[ $attribute->name ] = $attribute->value;
+		}
+		$new_image_html = wp_get_attachment_image( $block['attrs']['id'] ?? null, $block['attrs']['sizeSlug'] ?? 'full', false, $old_image_attrs );
 
 		/**
 		 * If there is no image, we cannot do anything.
 		 */
 		if ( empty( $new_image_html ) ) {
 			return $block_content;
-		}
-
-		/**
-		 * Re-add attributes from the original image to the new image.
-		 */
-		foreach ( $block_image->attributes as $attribute ) {
-			$new_image_html = str_replace( '<img', '<img ' . $attribute->name . '="' . $attribute->value . '"', $new_image_html );
 		}
 
 		/**


### PR DESCRIPTION
This PR fixes an issue with the lazysizes module.

The block-editors set's several attributes to the img tag, for example for aspect-ratio. Those attributes are currently missing as by the core/image block is parsed via the lazysizes module. This is fixed by simple re-adding them.

see for example https://github.com/luehrsenheinrich/efm-2025/issues/334