### PR TITLE
Refactor the Icons Component to handle thousands of icons

### DIFF
--- a/plugin-test/blocks/demo/edit.js
+++ b/plugin-test/blocks/demo/edit.js
@@ -5,9 +5,11 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
 const { IconSelectControl } = window.lhbasics.components;
-import { useState } from '@wordpress/element';
-const Edit = () => {
-	const [selectedIcon, setSelectedIcon] = useState();
+
+const Edit = (props) => {
+	const { attributes, setAttributes } = props;
+
+	const { icon } = attributes;
 
 	return (
 		<>
@@ -16,8 +18,8 @@ const Edit = () => {
 					<p>{__('This is a demo block.', 'lhpbpp')}</p>
 					<IconSelectControl
 						label={__('Select an icon', 'lhpbpp')}
-						value={selectedIcon}
-						onChange={setSelectedIcon}
+						value={icon}
+						onChange={(value) => setAttributes({ icon: value })}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/plugin-test/blocks/demo/edit.js
+++ b/plugin-test/blocks/demo/edit.js
@@ -4,13 +4,21 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-
+const { IconSelectControl } = window.lhbasics.components;
+import { useState } from '@wordpress/element';
 const Edit = () => {
+	const [selectedIcon, setSelectedIcon] = useState();
+
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={__('Settings', 'lhpbpp')}>
 					<p>{__('This is a demo block.', 'lhpbpp')}</p>
+					<IconSelectControl
+						label={__('Select an icon', 'lhpbpp')}
+						value={selectedIcon}
+						onChange={setSelectedIcon}
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<div {...useBlockProps()}>

--- a/plugin-test/inc/Blocks/Blocks.php
+++ b/plugin-test/inc/Blocks/Blocks.php
@@ -70,7 +70,7 @@ class Blocks extends Plugin_Component {
 			wp_enqueue_script(
 				'basicsTestp-blocks-helper',
 				plugin()->get_plugin_url() . 'admin/dist/js/blocks-helper.min.js',
-				array_merge( array(), $block_helper_assets['dependencies'] ),
+				array_merge( array( 'lhbasics-blocks-helper' ), $block_helper_assets['dependencies'] ),
 				$block_helper_assets['version'],
 				true
 			);
@@ -80,7 +80,7 @@ class Blocks extends Plugin_Component {
 		wp_enqueue_script(
 			'basicsTestp-blocks',
 			plugin()->get_plugin_url() . 'admin/dist/js/blocks.min.js',
-			array_merge( array(), $block_assets['dependencies'] ),
+			array_merge( array( 'lhbasics-blocks-helper' ), $block_assets['dependencies'] ),
 			$block_assets['version'],
 			true
 		);

--- a/plugin/admin/src/css/components.css
+++ b/plugin/admin/src/css/components.css
@@ -1,0 +1,1 @@
+@import "components/icon-select-control.css";

--- a/plugin/admin/src/css/components/icon-select-control.css
+++ b/plugin/admin/src/css/components/icon-select-control.css
@@ -1,0 +1,23 @@
+/* Our own elements used within the control */
+.lh-icon-select-control {
+	--lhisc-icon-size: 20px;
+	--lhisc-grid-gap: 12px;
+	width: 100%;
+	color: #333;
+
+	& input[type="text"]:focus {
+		box-shadow: none;
+	}
+}
+
+.lh-icon-select-option-label {
+	display: grid;
+	grid-template-columns: var(--lhisc-icon-size) auto;
+	grid-column-gap: var(--lhisc-grid-gap);
+	align-items: center;
+
+	& .lh-icon svg {
+		display: block;
+		max-height: var(--lhisc-icon-size);
+	}
+}

--- a/plugin/admin/src/js/blocks-helper.js
+++ b/plugin/admin/src/js/blocks-helper.js
@@ -1,0 +1,14 @@
+/**
+ * Blocks Helper Module
+ *
+ * This module is responsible for importing and registering the IconSelectControl component
+ * to the global lhbasics.components namespace.
+ */
+
+// Import the IconSelectControl component
+import IconSelectControl from './components/icon-select-control';
+
+// Register the IconSelectControl component to the global lhbasics.components namespace
+window.lhbasics = window.lhbasics || {};
+window.lhbasics.components = window.lhbasics.components || {};
+window.lhbasics.components.IconSelectControl = IconSelectControl;

--- a/plugin/admin/src/js/components/icon-select-control/Readme.md
+++ b/plugin/admin/src/js/components/icon-select-control/Readme.md
@@ -1,0 +1,80 @@
+# IconSelectControl
+
+IconSelectControl is a component for selecting icons from a list. It leverages react-select along with custom hooks to provide a searchable, clearable dropdown. The component ensures that the currently selected icon is always available in the options—even if it would normally be filtered out—by using dedicated hooks to load the icon data.
+
+## Example Usage
+
+```jsx
+import { useState } from '@wordpress/element';
+import IconSelectControl from 'path/to/IconSelectControl';
+
+const MyIconSelector = () => {
+	const [ selectedIcon, setSelectedIcon ] = useState( null );
+
+	return (
+		<IconSelectControl
+			label="Select Icon"
+			help="Choose an icon from the list."
+			value={ selectedIcon }
+			onChange={ setSelectedIcon }
+			// Optionally, use whiteList to include only specific icons:
+			// whiteList={ [ 'home', 'settings', 'user' ] }
+			// Or use blackList to exclude certain icons:
+			// blackList={ [ 'delete' ] }
+		/>
+	);
+};
+
+export default MyIconSelector;
+```
+
+## Props
+
+### `label`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `'Select icon'`
+- **Description:** The text label displayed above the control.
+
+### `help`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `''`
+- **Description:** Additional help text that provides guidance about the control. This text is associated with the input for accessibility.
+
+### `value`
+
+- **Type:** `string`
+- **Required:** No
+- **Description:** The slug of the currently selected icon. If no value is provided, the control appears empty.
+
+### `onChange`
+
+- **Type:** `(value: string | null) => void`
+- **Required:** Yes
+- **Description:** Callback function invoked when the icon selection changes. It receives the new icon slug, or `null` if the selection is cleared.
+
+### `blackList`
+
+- **Type:** `string[]`
+- **Required:** No
+- **Default:** `[]`
+- **Description:** An array of icon slugs to exclude from the available selection options.
+
+### `whiteList`
+
+- **Type:** `string[]`
+- **Required:** No
+- **Default:** `[]`
+- **Description:** An array of icon slugs to exclusively include in the selection options. If provided, only these icons will be available for selection.
+
+## Internal Behavior
+
+IconSelectControl utilizes two custom hooks:
+
+- **useIcons:** Retrieves a list of icons filtered by a search term. It accepts a `must_include` parameter to ensure that the icon corresponding to the current value is always included.
+- **useIcon:** Fetches a specific icon by its slug if it is not already present in the icons list, ensuring that the control always displays the current selection.
+
+The component renders a searchable dropdown using react-select, with a custom option renderer that displays each icon (using a dedicated icon component) alongside its title.

--- a/plugin/admin/src/js/components/icon-select-control/index.js
+++ b/plugin/admin/src/js/components/icon-select-control/index.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies.
+ */
+import { useEffect, useState } from '@wordpress/element';
+import {
+	BaseControl,
+	Spinner,
+	useBaseControlProps,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies.
+ */
+import Select from 'react-select';
+import { useIcons } from '../../data/entities/icon';
+
+/**
+ * Internal dependencies.
+ */
+import LHIcon from '../icon';
+
+const IconSelectControl = ({
+	label = __('Select icon', 'lhbasicsp'),
+	help = '',
+	value,
+	onChange,
+	blackList,
+	whiteList,
+}) => {
+	const [selectedOption, setSelectedOption] = useState();
+	const { baseControlProps, controlProps } = useBaseControlProps({
+		label,
+		help,
+	});
+	const { icons, ...fetchIcons } = useIcons();
+
+	useEffect(() => {
+		if (icons?.length && selectedOption?.value !== value) {
+			const icon = icons.find((i) => i?.slug === value) || {};
+			// Prepare the Select value.
+			setSelectedOption({
+				icon: { ...icon },
+				value: icon.slug,
+				label: icon.title,
+			});
+		}
+	}, [icons, value, selectedOption]);
+
+	const onSelectIcon = (option) => {
+		onChange(option?.value);
+		if (!option?.value) {
+			setSelectedOption(null);
+		}
+	};
+
+	let options = icons?.slice() || []; // Create a copy of the icons array
+
+	// Filter options over black- or whitelist, prefering white over blacklist.
+	if (whiteList?.length) {
+		options = options.filter(
+			(option) => whiteList.indexOf(option.slug) > -1
+		);
+	} else if (blackList?.length) {
+		options = options.filter(
+			(option) => blackList.indexOf(option.slug) < 0
+		);
+	}
+
+	return (
+		<BaseControl {...baseControlProps}>
+			{!fetchIcons?.hasResolved && <Spinner />}
+			{fetchIcons?.hasResolved && (
+				<Select
+					{...controlProps}
+					openMenuOnClick={true}
+					openMenuOnFocus={true}
+					classNamePrefix="react-select"
+					className="lh-icon-select-control react-select"
+					value={selectedOption}
+					onChange={onSelectIcon}
+					isSearchable={true}
+					isDisabled={!icons.length}
+					isClearable={true}
+					options={options.map((icon) => ({
+						icon: { ...icon },
+						value: icon.slug,
+						label: icon.title,
+					}))}
+					getOptionLabel={(option) => (
+						<div className="lh-icon-select-option-label">
+							<LHIcon
+								slug={option.icon.slug}
+								svg={option.icon.svg}
+							/>
+							<span>{option.label}</span>
+						</div>
+					)}
+				/>
+			)}
+		</BaseControl>
+	);
+};
+
+export default IconSelectControl;

--- a/plugin/admin/src/js/components/icon-select-control/index.js
+++ b/plugin/admin/src/js/components/icon-select-control/index.js
@@ -9,10 +9,14 @@ import { __ } from '@wordpress/i18n';
  * External dependencies.
  */
 import Select from 'react-select';
+
+/**
+ * Custom hooks for icon data.
+ */
 import { useIcons, useIcon } from '../../data/entities/icon';
 
 /**
- * Internal dependencies.
+ * Internal dependency: a component for rendering an icon.
  */
 import LHIcon from '../icon';
 
@@ -24,63 +28,105 @@ const IconSelectControl = ({
 	blackList = [],
 	whiteList = [],
 }) => {
+	// Local state to hold the currently selected option.
 	const [selectedOption, setSelectedOption] = useState(null);
+	// Local state to control the search term for filtering icons.
 	const [searchTerm, setSearchTerm] = useState('');
+
+	// Get base control props for consistent label and help text handling.
 	const { baseControlProps, controlProps } = useBaseControlProps({
 		label,
 		help,
 	});
+
+	// Retrieve icons matching the search term.
+	// The "must_include" parameter ensures that the icon matching the current "value" is always present.
 	const { icons, hasResolved } = useIcons({
 		search: searchTerm,
 		must_include: value,
 	});
 
-	// Load the icon for the current value, it might not have been in the initial list of icons.
+	// Load the icon for the current value using a dedicated hook.
+	// This is useful if the icon is not present in the initial list.
 	const { icon: valueIcon, hasResolved: valueIconHasResolved } =
 		useIcon(value);
 
-	// If the valueIcon has resolved and selectedOption is not set, set it.
+	/**
+	 * Consolidated effect to update the selected option.
+	 *
+	 * If no "value" is provided, the selected option is cleared.
+	 * Otherwise, this effect first prefers the dedicated valueIcon (if resolved),
+	 * and then falls back to searching the icon in the icons list.
+	 * The selected option is only updated if it differs from the current state.
+	 */
 	useEffect(() => {
-		if (valueIconHasResolved && valueIcon && !selectedOption) {
+		// Clear the selection if no value is provided.
+		if (!value) {
+			if (selectedOption !== null) {
+				setSelectedOption(null);
+			}
+			return;
+		}
+
+		// Determine the new icon data from useIcon (if available) or from the icons list.
+		let newIcon = null;
+		if (valueIconHasResolved && valueIcon) {
+			newIcon = valueIcon;
+		} else if (icons && icons.length) {
+			newIcon = icons.find((i) => i.slug === value) || null;
+		}
+
+		// Update the selected option if the icon exists and is different from the current selection.
+		if (
+			newIcon &&
+			(!selectedOption || selectedOption.value !== newIcon.slug)
+		) {
 			setSelectedOption({
-				icon: valueIcon,
-				value: valueIcon.slug,
-				label: valueIcon.title,
+				icon: newIcon,
+				value: newIcon.slug,
+				label: newIcon.title,
 			});
 		}
-	}, [valueIcon, valueIconHasResolved, selectedOption]);
+	}, [value, valueIcon, valueIconHasResolved, icons, selectedOption]);
 
-	useEffect(() => {
-		if (icons?.length && value) {
-			const icon = icons.find((i) => i.slug === value) || null;
-			if (icon && selectedOption?.value !== icon.slug) {
-				setSelectedOption({
-					icon,
-					value: icon.slug,
-					label: icon.title,
-				});
-			}
-		} else if (!value && selectedOption) {
-			setSelectedOption(null);
-		}
-	}, [icons, value, selectedOption]); // include selectedOption here
-
+	/**
+	 * Event handler for when an icon is selected.
+	 *
+	 * Updates both the parent value (via onChange) and the internal selected option.
+	 *
+	 * @param {Object|null} option The selected option, or null if cleared.
+	 */
 	const onSelectIcon = (option) => {
 		onChange(option?.value || null);
 		setSelectedOption(option || null);
 	};
 
+	/**
+	 * Event handler for input change in the search field.
+	 *
+	 * Updates the local searchTerm state.
+	 *
+	 * @param {string} inputValue The new input value.
+	 */
 	const onInputChange = (inputValue) => {
 		setSearchTerm(inputValue);
 	};
 
+	// Prepare the icons as options for react-select.
+	// Also apply whitelist or blacklist filtering if provided.
 	let options = icons ? [...icons] : [];
-
-	if (whiteList.length) {
+	if (whiteList.length > 0) {
 		options = options.filter((option) => whiteList.includes(option.slug));
-	} else if (blackList.length) {
+	} else if (blackList.length > 0) {
 		options = options.filter((option) => !blackList.includes(option.slug));
 	}
+
+	// Map each icon to the format required by react-select.
+	const selectOptions = options.map((icon) => ({
+		icon,
+		value: icon.slug,
+		label: icon.title,
+	}));
 
 	return (
 		<BaseControl {...baseControlProps}>
@@ -97,11 +143,12 @@ const IconSelectControl = ({
 				inputValue={searchTerm}
 				isClearable
 				isLoading={!hasResolved}
-				options={options.map((icon) => ({
-					icon,
-					value: icon.slug,
-					label: icon.title,
-				}))}
+				options={selectOptions}
+				/**
+				 * Custom renderer for the options in the dropdown.
+				 * Renders the icon (via LHIcon) along with its title.
+				 * @param {Object} option
+				 */
 				getOptionLabel={(option) => (
 					<div className="lh-icon-select-option-label">
 						<LHIcon slug={option.icon.slug} svg={option.icon.svg} />

--- a/plugin/admin/src/js/components/icon/Readme.md
+++ b/plugin/admin/src/js/components/icon/Readme.md
@@ -1,0 +1,83 @@
+# LHIcon
+
+LHIcon is a component that displays an icon from a custom API endpoint using the WordPress Icon component (wp.components.Icon) for consistent styling. It accepts an icon slug and optionally an SVG markup string. If the SVG is not provided, the component uses the slug to fetch the icon data via the useIcon hook.
+
+## Usage
+
+LHIcon integrates seamlessly with Gutenberg and custom interfaces. For example:
+
+```jsx
+import { useState } from '@wordpress/element';
+import LHIcon from 'path/to/LHIcon';
+
+const Example = () => {
+  const [ iconSlug, setIconSlug ] = useState('home');
+
+  return (
+    <div>
+      <LHIcon slug={ iconSlug } className="my-custom-class" />
+    </div>
+  );
+};
+
+export default Example;
+```
+
+## Props
+
+### `slug`
+- **Type:** `string`
+- **Required:** Yes
+The unique identifier for the icon to be displayed. LHIcon uses this slug to fetch the icon’s SVG markup if one is not provided via props.
+
+### `svg`
+- **Type:** `string`
+- **Required:** No
+An optional SVG markup string. If provided, LHIcon will render this SVG instead of fetching it from the API.
+
+### `className`
+- **Type:** `string`
+- **Required:** No
+Additional CSS classes to apply to the rendered icon. The component combines any provided classes with its default class names.
+
+### Other Props
+Any additional props passed to LHIcon are forwarded to the underlying WordPress Icon component.
+
+## Internal Behavior
+
+- **Data Fetching:**
+  LHIcon uses the useIcon hook to retrieve icon data based on the provided slug. The fetched data includes the SVG markup along with optional sizing attributes.
+
+- **SVG Parsing:**
+  The component uses html-react-parser to convert the raw SVG markup into React elements. This parsed SVG is memoized to optimize performance and avoid unnecessary re-parsing.
+
+- **Rendering:**
+  When icon data is available and the SVG is successfully parsed, LHIcon renders a WPIcon element. It computes a CSS class by combining any user-specified class names with a default pattern (e.g., `lh-icon icon-[slug]`). It also sets the icon size based on the available icon dimensions.
+
+## Example
+
+Below is an example of how to integrate LHIcon into your application:
+
+```jsx
+import { useState } from '@wordpress/element';
+import LHIcon from 'path/to/LHIcon';
+
+const IconDisplay = () => {
+  const [ selectedIcon, setSelectedIcon ] = useState('settings');
+
+  return (
+    <div>
+      <h2>Selected Icon</h2>
+      <LHIcon slug={ selectedIcon } className="custom-icon-style" />
+    </div>
+  );
+};
+
+export default IconDisplay;
+```
+
+## See Also
+
+- [WordPress Icon Component Documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/icon)
+
+LHIcon is part of the LH Basics Plugin and provides a convenient way to integrate custom icon functionality into your WordPress projects using the established design patterns of Gutenberg.

--- a/plugin/admin/src/js/components/icon/index.js
+++ b/plugin/admin/src/js/components/icon/index.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies.
+ */
+import { useMemo } from '@wordpress/element';
+import { Icon as WPIcon } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import classNames from 'classnames';
+import parse, { attributesToProps, domToReact } from 'html-react-parser';
+
+/**
+ * Internal dependencies.
+ */
+import { useIcon } from '../../data/entities/icon';
+
+/**
+ * Returns a wp.components.Icon element with icon from API.
+ *
+ * @param {Object} props           - Component props.
+ * @param {string} props.slug      - Icon slug.
+ * @param {string} props.svg       - Icon SVG.
+ * @param {string} props.className - Icon class name.
+ *
+ * @return {Object} - Icon component.
+ */
+const LHIcon = (props) => {
+	const { slug, svg } = props;
+	const { icon } = useIcon(slug);
+
+	// Further processing of the icon data.
+	const markup = svg || icon?.svg;
+	const parsedSvg = useMemo(
+		() => (markup ? parse(markup, getParserOptions()) : null),
+		[markup]
+	);
+
+	if (icon && parsedSvg) {
+		const className = classNames(
+			props?.className || '',
+			`lh-icon icon-${icon?.slug || slug || 'svg'}`
+		);
+
+		return (
+			<WPIcon
+				{...props}
+				icon={parsedSvg}
+				className={className}
+				size={parseInt(icon?.width || icon?.height) || null}
+			/>
+		);
+	}
+
+	return <></>;
+};
+
+export default LHIcon;
+
+/**
+ * Returns the parser options for the html-react-parser library.
+ */
+const getParserOptions = () => {
+	return {
+		replace: (domNode) => {
+			if (domNode.name === 'svg') {
+				// Define the custom tag name.
+				const CustomTag = domNode.name;
+				const props = attributesToProps(domNode.attribs);
+
+				return (
+					<CustomTag {...props} key={domNode.attribs.id}>
+						{domToReact(domNode.children)}
+					</CustomTag>
+				);
+			}
+			return domNode;
+		},
+	};
+};

--- a/plugin/admin/src/js/data/entities/Readme.md
+++ b/plugin/admin/src/js/data/entities/Readme.md
@@ -1,0 +1,98 @@
+# Icon Data Module
+
+This module registers two icon-related entities with the WordPress Core Data store and provides custom hooks to fetch icon data. It allows you to retrieve a list of icons with filtering and pagination or a single icon by its slug.
+
+## Entities
+
+Two entities are registered:
+
+- **Icon**
+  - **Label:** "Icon"
+  - **Name:** `icon`
+  - **Kind:** `single`
+  - **Base URL:** `/lhbasics/v1/icon`
+  - **Key:** `slug`
+
+- **Icons**
+  - **Label:** "Icons"
+  - **Name:** `icons`
+  - **Kind:** `root`
+  - **Base URL:** `/lhbasics/v1/icons`
+  - **Key:** `slug`
+
+## Hooks
+
+### `useIcons`
+
+Retrieves a list of icons with optional filtering and pagination.
+
+**Parameters:**
+
+- `params` (Object, optional):
+  - `search` (string): A term to filter icons by title. Default is an empty string (`''`).
+  - `page` (number): The page number for pagination. Default is `1`.
+  - `per_page` (number): The number of icons to retrieve per page. Default is `20`.
+
+**Returns:**
+
+An object containing:
+- `icons`: The array of icon records.
+- Additional state properties provided by `useEntityRecords` (such as `isResolving` and `error`).
+
+### `useIcon`
+
+Retrieves a single icon by its slug.
+
+**Parameters:**
+
+- `slug` (string): The unique slug identifier for the icon.
+
+**Returns:**
+
+An object containing:
+- `icon`: The icon record.
+- Additional state properties provided by `useEntityRecord` (such as `isResolving` and `error`).
+
+## Example Usage
+
+```jsx
+import { useIcons, useIcon } from '/';
+
+const IconGallery = () => {
+  // Retrieve a paginated list of icons with an optional search term.
+  const { icons, isResolving, error } = useIcons({ search: 'arrow', page: 1, per_page: 20 });
+
+  // Retrieve a specific icon by its slug.
+  const { icon } = useIcon('arrow-left');
+
+  if (isResolving) {
+    return <div>Loading icons...</div>;
+  }
+
+  if (error) {
+    return <div>Error loading icons.</div>;
+  }
+
+  return (
+    <div>
+      <h2>Icon Gallery</h2>
+      {icons && icons.map((icon) => (
+        <div key={icon.slug}>
+          <h3>{icon.title}</h3>
+          <div dangerouslySetInnerHTML={{ __html: icon.svg }} />
+        </div>
+      ))}
+      {icon && (
+        <div>
+          <h3>Selected Icon: {icon.title}</h3>
+          <div dangerouslySetInnerHTML={{ __html: icon.svg }} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default IconGallery;
+```
+
+This module leverages the WordPress Core Data store to register and manage icon entities. Use the provided hooks to seamlessly integrate icon selection and display functionality into your Gutenberg or custom WordPress components.

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -9,15 +9,8 @@ import {
 // Register icons as entities.
 dispatch(coreStore).addEntities([
 	{
-		label: 'Icon',
-		name: 'icon',
-		kind: 'single',
-		baseURL: '/lhbasics/v1/icon',
-		key: 'slug',
-	},
-	{
 		label: 'Icons',
-		name: 'icons',
+		name: 'icon',
 		kind: 'root',
 		baseURL: '/lhbasics/v1/icons',
 		key: 'slug',
@@ -35,7 +28,7 @@ dispatch(coreStore).addEntities([
  */
 export const useIcons = (params = {}) => {
 	const { search = '', page = 1, per_page = 20 } = params;
-	const { records: icons, ...states } = useEntityRecords('root', 'icons', {
+	const { records: icons, ...states } = useEntityRecords('root', 'icon', {
 		search,
 		page,
 		per_page,
@@ -50,6 +43,6 @@ export const useIcons = (params = {}) => {
  * @return {Object} An object containing the icon (as `record`) and other state properties.
  */
 export const useIcon = (slug) => {
-	const { record: icon, ...states } = useEntityRecord('single', 'icon', slug);
+	const { record: icon, ...states } = useEntityRecord('root', 'icon', slug);
 	return { icon, ...states };
 };

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -29,12 +29,11 @@ dispatch(coreStore).addEntities([
  * @param {Object} params
  */
 export const useIcons = (params = {}) => {
-	// eslint-disable-next-line camelcase
+	/* eslint-disable camelcase */
 	const { search = '', page = 1, per_page = 20 } = params;
 
 	// Map records to icons, pass everything else.
 	const { records: icons, ...states } = useEntityRecords('root', 'icons', {
-		// eslint-disable-next-line camelcase
 		per_page,
 		page,
 		search,

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -25,11 +25,19 @@ dispatch(coreStore).addEntities([
 
 /**
  * Returns all icons.
+ *
+ * @param {Object} params
  */
-export const useIcons = () => {
+export const useIcons = (params = {}) => {
+	// eslint-disable-next-line camelcase
+	const { search = '', page = 1, per_page = 20 } = params;
+
 	// Map records to icons, pass everything else.
 	const { records: icons, ...states } = useEntityRecords('root', 'icons', {
-		per_page: 100,
+		// eslint-disable-next-line camelcase
+		per_page,
+		page,
+		search,
 	});
 	return { icons, ...states };
 };

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { dispatch } from '@wordpress/data';
 import {
 	store as coreStore,
@@ -24,32 +25,31 @@ dispatch(coreStore).addEntities([
 ]);
 
 /**
- * Returns all icons.
+ * Retrieves a list of icons with optional filtering and pagination.
  *
- * @param {Object} params
+ * @param {Object} [params={}]          - Query parameters for filtering icons.
+ * @param {string} [params.search='']   - A search term to filter icons by title.
+ * @param {number} [params.page=1]      - The page number for pagination.
+ * @param {number} [params.per_page=20] - The number of icons to retrieve per page.
+ * @return {Object} An object containing the icons (as `records`) and other state properties.
  */
 export const useIcons = (params = {}) => {
-	/* eslint-disable camelcase */
 	const { search = '', page = 1, per_page = 20 } = params;
-
-	// Map records to icons, pass everything else.
 	const { records: icons, ...states } = useEntityRecords('root', 'icons', {
-		per_page,
-		page,
 		search,
+		page,
+		per_page,
 	});
 	return { icons, ...states };
 };
 
 /**
- * Returns a single icon.
+ * Retrieves a single icon by its slug.
  *
- * @param {string} slug - Icon slug.
- *
- * @return {Object} - Icon object.
+ * @param {string} slug - The unique slug identifier for the icon.
+ * @return {Object} An object containing the icon (as `record`) and other state properties.
  */
 export const useIcon = (slug) => {
-	// Map record to icon, pass everything else.
 	const { record: icon, ...states } = useEntityRecord('single', 'icon', slug);
 	return { icon, ...states };
 };

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -1,0 +1,48 @@
+import { dispatch } from '@wordpress/data';
+import {
+	store as coreStore,
+	useEntityRecord,
+	useEntityRecords,
+} from '@wordpress/core-data';
+
+// Register icons as entities.
+dispatch(coreStore).addEntities([
+	{
+		label: 'Icon',
+		name: 'icon',
+		kind: 'single',
+		baseURL: '/lhbasics/v1/icon',
+		key: 'slug',
+	},
+	{
+		label: 'Icons',
+		name: 'icons',
+		kind: 'root',
+		baseURL: '/lhbasics/v1/icons',
+		key: 'slug',
+	},
+]);
+
+/**
+ * Returns all icons.
+ */
+export const useIcons = () => {
+	// Map records to icons, pass everything else.
+	const { records: icons, ...states } = useEntityRecords('root', 'icons', {
+		per_page: 100,
+	});
+	return { icons, ...states };
+};
+
+/**
+ * Returns a single icon.
+ *
+ * @param {string} slug - Icon slug.
+ *
+ * @return {Object} - Icon object.
+ */
+export const useIcon = (slug) => {
+	// Map record to icon, pass everything else.
+	const { record: icon, ...states } = useEntityRecord('single', 'icon', slug);
+	return { icon, ...states };
+};

--- a/plugin/admin/src/js/lhbasics.js
+++ b/plugin/admin/src/js/lhbasics.js
@@ -18,3 +18,8 @@ window.lhbasics = {};
  * The settings object for the plugin.
  */
 window.lhbasics.settings = SettingsObject;
+
+/**
+ * The components we expose.
+ */
+window.lhbasics.components = {};

--- a/plugin/inc/Blocks/Blocks.php
+++ b/plugin/inc/Blocks/Blocks.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Blocks Class
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\Blocks;
+use WpMunich\basics\plugin\Plugin_Component;
+
+use function WpMunich\basics\plugin\plugin;
+
+/**
+ * A class to handle Blocks related logic.
+ */
+class Blocks extends Plugin_Component {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_actions() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_filters() {}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public function enqueue_block_editor_assets() {
+		$assets = wp_json_file_decode( plugin()->get_plugin_path() . '/admin/dist/assets.json', array( 'associative' => true ) );
+
+		$blocks_helper_assets = $assets['js/blocks-helper.min.js'] ?? array();
+		wp_enqueue_script(
+			'lhbasics-blocks-helper',
+			plugin()->get_plugin_url() . '/admin/dist/js/blocks-helper.min.js',
+			array_merge( array( 'lhbasics' ), $blocks_helper_assets['dependencies'] ),
+			$blocks_helper_assets['version'],
+			true
+		);
+
+		wp_enqueue_style(
+			'lhbasicsp-admin-components',
+			plugin()->get_plugin_url() . '/admin/dist/css/components.min.css',
+			array(),
+			plugin()->get_plugin_version(),
+			'all'
+		);
+	}
+}

--- a/plugin/inc/Plugin.php
+++ b/plugin/inc/Plugin.php
@@ -19,6 +19,7 @@ class Plugin {
 	/**
 	 * Constructor.
 	 *
+	 * @param Blocks\Blocks                     $blocks The blocks component.
 	 * @param i18n\I18N                         $i18n The i18n component.
 	 * @param Disable_Comments\Disable_Comments $disable_comments The disable comments component.
 	 * @param Gravity_Forms\Gravity_Forms       $gravity_forms The gravity forms component.
@@ -30,6 +31,7 @@ class Plugin {
 	 * @param SVG\SVG                           $svg The svg component.
 	 */
 	public function __construct(
+		private Blocks\Blocks $blocks,
 		private i18n\I18N $i18n,
 		private Disable_Comments\Disable_Comments $disable_comments,
 		private Gravity_Forms\Gravity_Forms $gravity_forms,

--- a/plugin/inc/SVG/Icon_Library.php
+++ b/plugin/inc/SVG/Icon_Library.php
@@ -46,7 +46,7 @@ class Icon_Library {
 	/**
 	 * Get all registered icons.
 	 *
-	 * @return array Array of icons.
+	 * @return Icon[] Array of icons.
 	 */
 	public function get_icons() {
 		return $this->icons;

--- a/plugin/inc/SVG/REST.php
+++ b/plugin/inc/SVG/REST.php
@@ -3,7 +3,7 @@
  * The SVG REST class.
  *
  * This file defines the `REST` class, which registers and manages custom REST API endpoints
- * for svg icons.
+ * for SVG icons.
  *
  * @package lhbasicsp
  */
@@ -11,11 +11,12 @@
 namespace WpMunich\basics\plugin\SVG;
 
 use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
 
 use function WpMunich\basics\plugin\plugin;
 use function add_action;
 use function apply_filters;
-use function esc_attr;
 use function register_rest_route;
 use function rest_ensure_response;
 use function wp_parse_args;
@@ -23,7 +24,7 @@ use function wp_parse_args;
 /**
  * REST
  *
- * A class to register and manage svg/icon custom REST API endpoints.
+ * A class to register and manage SVG/icon custom REST API endpoints.
  */
 class REST {
 
@@ -32,27 +33,23 @@ class REST {
 	 *
 	 * @var string
 	 */
-	private $rest_namespace = 'lhbasics/v1'; // Could be outsourced to a "blank" REST component or similar.
+	private string $rest_namespace = 'lhbasics/v1';
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		$this->add_actions();
-		$this->add_filters();
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Add WordPress actions.
+	 *
+	 * @return void
 	 */
 	protected function add_actions() {
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	protected function add_filters() {}
 
 	/**
 	 * Register custom REST API routes.
@@ -60,28 +57,42 @@ class REST {
 	 * @return void
 	 */
 	public function register_rest_routes() {
-		// Route to retrieve all icons.
 		register_rest_route(
 			$this->rest_namespace,
-			'icons',
+			'/icons/',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'rest_get_icons' ),
 				'permission_callback' => '__return_true',
+				'args'                => array(
+					'page'     => array(
+						'required'          => false,
+						'default'           => 1,
+						'validate_callback' => 'absint',
+					),
+					'per_page' => array(
+						'required'          => false,
+						'default'           => 10,
+						'validate_callback' => function( $value ) {
+							$value = absint( $value );
+							return $value > 0 && $value <= 100 ? $value : 100;
+						},
+					),
+				),
 			)
 		);
 
-		// Route to retrieve a single icon by slug.
 		register_rest_route(
 			$this->rest_namespace,
-			'icon(?:/(?<slug>[a-z0-9-]+))?',
+			'/icon/(?P<slug>[a-z0-9-]+)/',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'rest_get_icon' ),
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'slug' => array(
-						'type' => 'string',
+						'required' => true,
+						'type'     => 'string',
 					),
 				),
 			)
@@ -89,126 +100,68 @@ class REST {
 	}
 
 	/**
-	 * Retrieve all icons from the icon library via REST.
+	 * Retrieve all icons with pagination.
 	 *
-	 * Returns a filtered list of icons available in the plugin's icon library. This includes
-	 * options to restrict results based on specific icon slugs provided as a comma-separated
-	 * parameter in the request.
-	 *
-	 * @param  WP_REST_Request $request The request.
-	 *
-	 * @return WP_REST_Response The response containing icon data.
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response The response containing paginated icon data.
 	 */
-	public function rest_get_icons( $request ) {
+	public function rest_get_icons( WP_REST_Request $request ): WP_REST_Response {
 		$slugs     = $request->get_param( 'slugs' );
 		$lib_icons = plugin()->svg()->get_icon_library()->get_icons();
-		$res_icons = array();
 
-		// Process the `slugs` parameter, if provided.
-		if ( $slugs && ! empty( $slugs ) ) {
-			$slugs = explode( ',', $slugs );
-		}
+		$page        = max( 1, $request->get_param( 'page' ) );
+		$per_page    = min( max( 1, $request->get_param( 'per_page' ) ), 100 );
+		$total_icons = count( $lib_icons );
+		$total_pages = (int) ceil( $total_icons / $per_page );
 
-		// Loop through icons and filter based on visibility in REST API.
-		foreach ( $lib_icons as $icon ) {
-			if ( $icon->show_in_rest() ) {
-				if ( is_array( $slugs ) && ! in_array( $icon->get_slug(), $slugs, true ) ) {
-					continue;
+		if ( $slugs ) {
+			$slugs     = explode( ',', $slugs );
+			$lib_icons = array_filter(
+				$lib_icons,
+				function( $icon ) use ( $slugs ) {
+					return in_array( $icon->get_slug(), $slugs, true );
 				}
-
-				$res_icons[] = wp_parse_args(
-					$icon->jsonSerialize( array( 'slug', 'title' ) ),
-					array(
-						'svg' => plugin()->svg()->get_svg( $icon->get_slug() ),
-					)
-				);
-			}
+			);
 		}
-		return rest_ensure_response( $res_icons );
+
+		$offset      = ( $page - 1 ) * $per_page;
+		$paged_icons = array_slice( $lib_icons, $offset, $per_page );
+
+		$res_icons = array_map(
+			function( $icon ) {
+				return wp_parse_args(
+					$icon->jsonSerialize( array( 'slug', 'title' ) ),
+					array( 'svg' => plugin()->svg()->get_svg( $icon->get_slug() ) )
+				);
+			},
+			$paged_icons
+		);
+
+		$response = rest_ensure_response( $res_icons );
+		$response->header( 'X-WP-Total', $total_icons );
+		$response->header( 'X-WP-TotalPages', $total_pages );
+		$response->header( 'X-WP-Page', $page );
+
+		return $response;
 	}
 
 	/**
 	 * Retrieve a single icon by slug via REST.
 	 *
-	 * Accepts a `slug` parameter to identify the icon, and optional parameters for SVG attributes.
-	 * This enables API clients to specify icon attributes dynamically.
-	 *
-	 * @param  WP_REST_Request $request The request.
-	 *
+	 * @param WP_REST_Request $request The request.
 	 * @return WP_REST_Response The response containing the requested icon data.
 	 */
-	public function rest_get_icon( $request ) {
+	public function rest_get_icon( WP_REST_Request $request ): WP_REST_Response {
 		$slug = $request->get_param( 'slug' );
-		$path = $request->get_param( 'path' );
-		$args = $this->get_args_from_request( $request );
-
-		$svg = plugin()->svg()->get_svg( $slug );
-
-		// Fallback to using `path` parameter if slug is not found.
-		if ( ! $svg && $path && ! empty( $path ) ) {
-			$svg = plugin()->svg()->get_svg( $path );
-		}
-
+		$svg  = plugin()->svg()->get_svg( $slug );
 		$icon = $slug && $svg ? plugin()->svg()->get_icon_library()->get_icon( $slug )->jsonSerialize( array( 'slug', 'title' ) ) : array();
 
 		$response = apply_filters(
 			'basicsp_rest_get_svg_response',
-			wp_parse_args(
-				$icon,
-				array( 'svg' => $svg )
-			),
-			$slug,
-			$args
+			wp_parse_args( $icon, array( 'svg' => $svg ) ),
+			$slug
 		);
 
 		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Helper function to map request parameters to SVG attributes.
-	 *
-	 * Extracts relevant attributes from the request and maps them to a format suitable
-	 * for the plugin's `get_svg` function, supporting dynamic SVG generation.
-	 *
-	 * @param WP_REST_Request $request The request to check for params.
-	 * @return array The $args array for `get_svg`.
-	 */
-	private function get_args_from_request( $request ) {
-		$args = array();
-		$attr = array();
-
-		if ( isset( $request['class'] ) ) {
-			$attr['class'] = esc_attr( $request['class'] );
-		}
-		if ( isset( $request['id'] ) ) {
-			$attr['id'] = esc_attr( $request['id'] );
-		}
-		if ( isset( $request['width'] ) ) {
-			$attr['width'] = esc_attr( $request['width'] );
-		}
-		if ( isset( $request['height'] ) ) {
-			$attr['height'] = esc_attr( $request['height'] );
-		}
-		if ( isset( $request['fill'] ) ) {
-			$attr['fill'] = esc_attr( $request['fill'] );
-		}
-
-		// Add attributes to $args if any were set.
-		if ( count( $attr ) ) {
-			$args['attributes'] = $attr;
-		}
-
-		return $args;
-	}
-
-	/**
-	 * Get the current REST namespace.
-	 *
-	 * Returns the namespace used for this component’s REST routes.
-	 *
-	 * @return string The REST namespace.
-	 */
-	public function get_namespace() {
-		return $this->rest_namespace;
 	}
 }

--- a/plugin/inc/SVG/REST.php
+++ b/plugin/inc/SVG/REST.php
@@ -2,7 +2,7 @@
 /**
  * The SVG REST class.
  *
- * This file defines the `REST` class, which registers and manages custom REST API endpoints
+ * This file defines the REST class, which registers and manages custom REST API endpoints
  * for SVG icons.
  *
  * @package lhbasicsp
@@ -29,7 +29,9 @@ use function wp_parse_args;
 class REST {
 
 	/**
-	 * The namespace for REST endpoints in this component.
+	 * The REST namespace.
+	 *
+	 * This string is used as the base namespace for all REST endpoints in this component.
 	 *
 	 * @var string
 	 */
@@ -37,6 +39,8 @@ class REST {
 
 	/**
 	 * Constructor.
+	 *
+	 * Initializes the REST endpoints by hooking into the appropriate WordPress actions.
 	 */
 	public function __construct() {
 		$this->add_actions();
@@ -44,6 +48,8 @@ class REST {
 
 	/**
 	 * Add WordPress actions.
+	 *
+	 * Hooks the method to register REST routes into the 'rest_api_init' action.
 	 *
 	 * @return void
 	 */
@@ -54,9 +60,14 @@ class REST {
 	/**
 	 * Register custom REST API routes.
 	 *
+	 * Registers two endpoints:
+	 * - /icons/ for retrieving a list of icons with pagination.
+	 * - /icon/(?P<slug>[a-z0-9-]+)/ for retrieving a single icon by slug.
+	 *
 	 * @return void
 	 */
 	public function register_rest_routes() {
+		// Register endpoint for retrieving paginated icons.
 		register_rest_route(
 			$this->rest_namespace,
 			'/icons/',
@@ -65,12 +76,12 @@ class REST {
 				'callback'            => array( $this, 'rest_get_icons' ),
 				'permission_callback' => '__return_true',
 				'args'                => array(
-					'page'     => array(
+					'page'         => array(
 						'required'          => false,
 						'default'           => 1,
 						'validate_callback' => 'absint',
 					),
-					'per_page' => array(
+					'per_page'     => array(
 						'required'          => false,
 						'default'           => 10,
 						'validate_callback' => function( $value ) {
@@ -78,10 +89,19 @@ class REST {
 							return $value > 0 && $value <= 100 ? $value : 100;
 						},
 					),
+					'search'       => array(
+						'required' => false,
+						'type'     => 'string',
+					),
+					'must_include' => array(
+						'required' => false,
+						'type'     => 'string',
+					),
 				),
 			)
 		);
 
+		// Register endpoint for retrieving a single icon by slug.
 		register_rest_route(
 			$this->rest_namespace,
 			'/icon/(?P<slug>[a-z0-9-]+)/',
@@ -102,18 +122,35 @@ class REST {
 	/**
 	 * Retrieve all icons with pagination.
 	 *
-	 * @param WP_REST_Request $request The request.
+	 * This method handles requests to the /icons/ endpoint. It optionally filters icons
+	 * by a search term and/or a comma-separated list of slugs, then paginates the result.
+	 *
+	 * @param WP_REST_Request $request The current REST API request.
 	 * @return WP_REST_Response The response containing paginated icon data.
 	 */
 	public function rest_get_icons( WP_REST_Request $request ): WP_REST_Response {
+		// Retrieve parameters from the request.
 		$slugs     = $request->get_param( 'slugs' );
+		$search    = $request->get_param( 'search' );
 		$lib_icons = plugin()->svg()->get_icon_library()->get_icons();
 
-		$page        = max( 1, $request->get_param( 'page' ) );
-		$per_page    = min( max( 1, $request->get_param( 'per_page' ) ), 100 );
+		// If a search term is provided, filter icons whose titles contain the term.
+		if ( $search ) {
+			$lib_icons = array_filter(
+				$lib_icons,
+				function( $icon ) use ( $search ) {
+					return false !== stripos( $icon->get_title(), $search );
+				}
+			);
+		}
+
+		// Retrieve pagination parameters.
+		$page        = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page    = min( max( 1, (int) $request->get_param( 'per_page' ) ), 100 );
 		$total_icons = count( $lib_icons );
 		$total_pages = (int) ceil( $total_icons / $per_page );
 
+		// If specific slugs are provided, filter icons to only include those.
 		if ( $slugs ) {
 			$slugs     = explode( ',', $slugs );
 			$lib_icons = array_filter(
@@ -124,19 +161,24 @@ class REST {
 			);
 		}
 
+		// Determine the offset and slice the icons array for the current page.
 		$offset      = ( $page - 1 ) * $per_page;
 		$paged_icons = array_slice( $lib_icons, $offset, $per_page );
 
+		// Prepare icons for the response by merging JSON data with the SVG markup.
 		$res_icons = array_map(
 			function( $icon ) {
 				return wp_parse_args(
 					$icon->jsonSerialize( array( 'slug', 'title' ) ),
-					array( 'svg' => plugin()->svg()->get_svg( $icon->get_slug() ) )
+					array(
+						'svg' => plugin()->svg()->get_svg( $icon->get_slug() ),
+					)
 				);
 			},
 			$paged_icons
 		);
 
+		// Create the REST response and add pagination headers.
 		$response = rest_ensure_response( $res_icons );
 		$response->header( 'X-WP-Total', $total_icons );
 		$response->header( 'X-WP-TotalPages', $total_pages );
@@ -148,14 +190,25 @@ class REST {
 	/**
 	 * Retrieve a single icon by slug via REST.
 	 *
-	 * @param WP_REST_Request $request The request.
+	 * This method handles requests to the /icon/(?P<slug>[a-z0-9-]+)/ endpoint.
+	 * It returns the JSON representation of the icon, including its SVG markup.
+	 *
+	 * @param WP_REST_Request $request The current REST API request.
 	 * @return WP_REST_Response The response containing the requested icon data.
 	 */
 	public function rest_get_icon( WP_REST_Request $request ): WP_REST_Response {
+		// Retrieve the icon slug from the request.
 		$slug = $request->get_param( 'slug' );
-		$svg  = plugin()->svg()->get_svg( $slug );
-		$icon = $slug && $svg ? plugin()->svg()->get_icon_library()->get_icon( $slug )->jsonSerialize( array( 'slug', 'title' ) ) : array();
 
+		// Get the SVG markup for the icon.
+		$svg = plugin()->svg()->get_svg( $slug );
+
+		// If the slug exists and SVG data is found, get the icon's JSON data.
+		$icon = $slug && $svg
+			? plugin()->svg()->get_icon_library()->get_icon( $slug )->jsonSerialize( array( 'slug', 'title' ) )
+			: array();
+
+		// Allow filtering of the response data.
 		$response = apply_filters(
 			'basicsp_rest_get_svg_response',
 			wp_parse_args( $icon, array( 'svg' => $svg ) ),

--- a/plugin/inc/SVG/REST.php
+++ b/plugin/inc/SVG/REST.php
@@ -104,6 +104,23 @@ class REST {
 		// Register endpoint for retrieving a single icon by slug.
 		register_rest_route(
 			$this->rest_namespace,
+			'/icons/(?P<slug>[a-z0-9-]+)/',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'rest_get_icon' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'slug' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+				),
+			)
+		);
+
+		// Keep the old route for compatibility reasons.
+		register_rest_route(
+			$this->rest_namespace,
 			'/icon/(?P<slug>[a-z0-9-]+)/',
 			array(
 				'methods'             => WP_REST_Server::READABLE,

--- a/plugin/inc/Settings/Settings.php
+++ b/plugin/inc/Settings/Settings.php
@@ -64,7 +64,8 @@ class Settings extends Plugin_Component {
 		$screen = get_current_screen();
 		$assets = wp_json_file_decode( plugin()->get_plugin_path() . '/admin/dist/assets.json', array( 'associative' => true ) );
 
-		wp_register_script( 'lhbasics', plugin()->get_plugin_url() . '/admin/dist/js/lhbasics.min.js', array(), plugin()->get_plugin_version(), true );
+		$lhbasics_assets = $assets['js/lhbasics.min.js'] ?? array();
+		wp_register_script( 'lhbasics', plugin()->get_plugin_url() . '/admin/dist/js/lhbasics.min.js', $lhbasics_assets['dependencies'], $lhbasics_assets['version'], true );
 
 		if ( in_array( $screen->id, array( 'settings_page_lhagentur-settings' ), true ) ) {
 			$admin_script_assets = $assets['js/admin-settings-page.min.js'] ?? array();


### PR DESCRIPTION
This PR refactors both the LHIcon and IconSelectControl components to improve performance, consistency, and maintainability. Additionally, IconSelectControl has been migrated from individual plugins into the LH Basics Plugin codebase.

**Changes:**

- **IconSelectControl:**
  - Consolidated state management and effects for syncing the selected option.
  - Improved option filtering with whitelist/blacklist support.
  - Ensured the currently selected icon is always included using the `must_include` parameter in the `useIcons` hook.
  - Migrated IconSelectControl from individual plugins into the LH Basics Plugin.

- **LHIcon:**
  - Refactored to memoize parsed SVG markup via `html-react-parser` for improved performance.
  - Enhanced props handling and fallback logic using the `useIcon` hook.

- **Documentation:**
  - Updated README files for both components, detailing usage, props, and internal behavior.

**Impact:**

These changes ensure a smoother user experience, adhere to WordPress/Gutenberg design patterns, and consolidate our icon components into a single, maintainable codebase. Please review and provide feedback.