### PR TITLE
register block assets in init to fix dependency RC

### DIFF
--- a/plugin/inc/Blocks/Blocks.php
+++ b/plugin/inc/Blocks/Blocks.php
@@ -19,6 +19,7 @@ class Blocks extends Plugin_Component {
 	 * {@inheritDoc}
 	 */
 	protected function add_actions() {
+		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 	}
 
@@ -28,26 +29,36 @@ class Blocks extends Plugin_Component {
 	protected function add_filters() {}
 
 	/**
-	 * Enqueue block editor assets.
+	 * Register assets.
 	 */
-	public function enqueue_block_editor_assets() {
-		$assets = wp_json_file_decode( plugin()->get_plugin_path() . '/admin/dist/assets.json', array( 'associative' => true ) );
+	public function register_assets() {
+		$assets = wp_json_file_decode(
+			plugin()->get_plugin_path() . '/admin/dist/assets.json',
+			array( 'associative' => true )
+		);
 
 		$blocks_helper_assets = $assets['js/blocks-helper.min.js'] ?? array();
-		wp_enqueue_script(
+		wp_register_script(
 			'lhbasics-blocks-helper',
 			plugin()->get_plugin_url() . '/admin/dist/js/blocks-helper.min.js',
 			array_merge( array( 'lhbasics' ), $blocks_helper_assets['dependencies'] ),
 			$blocks_helper_assets['version'],
 			true
 		);
-
-		wp_enqueue_style(
+		wp_register_style(
 			'lhbasicsp-admin-components',
 			plugin()->get_plugin_url() . '/admin/dist/css/components.min.css',
 			array(),
 			plugin()->get_plugin_version(),
 			'all'
 		);
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public function enqueue_block_editor_assets() {
+		wp_enqueue_script( 'lhbasics-blocks-helper' );
+		wp_enqueue_style( 'lhbasicsp-admin-components' );
 	}
 }

--- a/plugin/inc/Settings/Settings.php
+++ b/plugin/inc/Settings/Settings.php
@@ -62,15 +62,29 @@ class Settings extends Plugin_Component {
 	 */
 	public function enqueue_assets() {
 		$screen = get_current_screen();
-		$assets = wp_json_file_decode( plugin()->get_plugin_path() . '/admin/dist/assets.json', array( 'associative' => true ) );
+		$assets = wp_json_file_decode(
+			plugin()->get_plugin_path() . '/admin/dist/assets.json',
+			array( 'associative' => true )
+		);
 
 		$lhbasics_assets = $assets['js/lhbasics.min.js'] ?? array();
-		wp_register_script( 'lhbasics', plugin()->get_plugin_url() . '/admin/dist/js/lhbasics.min.js', $lhbasics_assets['dependencies'], $lhbasics_assets['version'], true );
+		wp_register_script(
+			'lhbasics',
+			plugin()->get_plugin_url() . '/admin/dist/js/lhbasics.min.js',
+			$lhbasics_assets['dependencies'],
+			$lhbasics_assets['version'],
+			true
+		);
 
 		if ( in_array( $screen->id, array( 'settings_page_lhagentur-settings' ), true ) ) {
 			$admin_script_assets = $assets['js/admin-settings-page.min.js'] ?? array();
-
-			wp_enqueue_script( 'lhagentur-settings-page', plugin()->get_plugin_url() . '/admin/dist/js/admin-settings-page.min.js', $admin_script_assets['dependencies'], $admin_script_assets['version'], true );
+			wp_enqueue_script(
+				'lhagentur-settings-page',
+				plugin()->get_plugin_url() . '/admin/dist/js/admin-settings-page.min.js',
+				array_merge( array(), $admin_script_assets['dependencies'] ),
+				$admin_script_assets['version'],
+				true
+			);
 
 			wp_localize_script(
 				'lhagentur-settings-page',
@@ -82,7 +96,12 @@ class Settings extends Plugin_Component {
 				)
 			);
 
-			wp_enqueue_style( 'lhagentur-settings-page', plugin()->get_plugin_url() . '/admin/dist/css/admin-settings-page.min.css', array( 'wp-components' ), plugin()->get_plugin_version() );
+			wp_enqueue_style(
+				'lhagentur-settings-page',
+				plugin()->get_plugin_url() . '/admin/dist/css/admin-settings-page.min.css',
+				array( 'wp-components' ),
+				plugin()->get_plugin_version()
+			);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes some race-condition with `register_/enque_style/script` by registering the blocks-helper script and component styles at `init` action.

Enqueue call for block editor assets have been adjusted accordingly.

To test for the Settings-Page:
- open `/plugin/inc/Settings.php`
- add `'lhbasics-blocks-helper'` as dependency for `'lhagentur-settings-page'` script
- add `'lhbasicsp-admin-components'` as dependency for `'lhagentur-settings-page'` style
- open `/plugin/admin/src/js/modules/settings-page.js`
- add a `<IconSelectControl />` from `window.lhbasics.components` somewhere
- check the Settings Page