### PR TITLE
Add/admin/js/component/media select control

### DIFF
--- a/plugin/admin/src/css/components.css
+++ b/plugin/admin/src/css/components.css
@@ -1,1 +1,2 @@
 @import "components/icon-select-control.css";
+@import "components/media-select-control.css";

--- a/plugin/admin/src/css/components/media-select-control.css
+++ b/plugin/admin/src/css/components/media-select-control.css
@@ -1,0 +1,59 @@
+.lh-media-select-control {
+	width: 100%;
+
+	& > .components-base-control__field > .components-button + .components-button {
+		margin-left: 1rem;
+		margin-top: 1rem;
+	}
+
+	& label {
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-transform: uppercase;
+		display: inline-block;
+		margin-bottom: calc(8px);
+		padding: 0;
+	}
+}
+
+.lh-media-select-control__container {
+	position: relative;
+
+	& img.components-responsive-wrapper__content {
+		width: auto;
+		height: auto;
+		max-width: 100%;
+		max-height: 100%;
+	}
+}
+
+.lh-media-select-control__toggle {
+	display: block;
+	width: 100%;
+	min-height: 90px;
+	padding: 8px 0;
+	line-height: 20px;
+	text-align: center;
+	background-color: #f0f0f0;
+	border-radius: 2px;
+}
+
+.lh-media-select-control__preview {
+	display: flex;
+	flex-flow: column;
+	flex-wrap: nowrap;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: auto;
+
+	& img {
+		max-width: 100%;
+		height: auto;
+	}
+}
+
+.lh-media-select-control__actions {
+	margin-top: 0.5rem;
+}

--- a/plugin/admin/src/js/blocks-helper.js
+++ b/plugin/admin/src/js/blocks-helper.js
@@ -8,6 +8,7 @@
 // Import components
 import IconSelectControl from './components/icon-select-control';
 import LHIcon from './components/icon';
+import MediaSelectControl from './components/media-select-control';
 
 window.lhbasics = window.lhbasics || {};
 window.lhbasics.components = window.lhbasics.components || {};
@@ -17,3 +18,6 @@ window.lhbasics.components.IconSelectControl = IconSelectControl;
 
 // Register the LHIcon component to the global lhbasics.components namespace
 window.lhbasics.components.LHIcon = LHIcon;
+
+// Register the MediaSelectControl component to the global lhbasics.components namespace
+window.lhbasics.components.MediaSelectControl = MediaSelectControl;

--- a/plugin/admin/src/js/components/media-select-control/Readme.md
+++ b/plugin/admin/src/js/components/media-select-control/Readme.md
@@ -1,0 +1,104 @@
+# MediaSelectControl
+
+IconSelectControl is a component for selecting media from the media library.
+Besides `lhbasics-blocks-helper` script and `lhbasicsp-admin-components`
+this component requires to enqueue wp media assets as well with `wp_enqueue_media()`
+
+## Example Usage
+
+```jsx
+import { useState } from '@wordpress/element';
+import MediaSelectControl from 'path/to/MediaSelectControl';
+
+const MyIconSelector = () => {
+	const [ mediaId, setMediaId ] = useState( null );
+
+	return (
+		<MediaSelectControl
+			value={mediaId}
+			onChange={setMediaId}
+			isSelected={true}
+		/>
+	);
+};
+
+export default MyIconSelector;
+```
+
+## Props
+
+### `label`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `'Select image'`
+- **Description:** The text label displayed above the control.
+
+### `labelSet`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `'Set image'`
+- **Description:** The text label displayed at the "set {media}" action control.
+
+### `help`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `''`
+- **Description:** Additional help text that provides guidance about the control. This text is associated with the input for accessibility.
+
+### `value`
+
+- **Type:** `number`
+- **Required:** No
+- **Description:** The id of the currently selected media. If no value is provided, the control renders a "Set {media}" button. If a value is present, a preview with "Replace / Remove" buttons is rendered.
+
+### `onChange`
+
+- **Type:** `(value: number | null) => void`
+- **Required:** Yes
+- **Description:** Callback function invoked when the media selection changes. It receives the new media id, or `null` if the selection is cleared.
+
+### `allowedTypes`
+
+- **Type:** `string[]`
+- **Required:** No
+- **Default:** `['image]`
+- **Description:** An array of mime types to allow to select from.
+
+### `imageSize`
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** `'full'`
+- **Description:** The image size to use for the preview. (Note: No effect on other media types besides 'image' at the moment.)
+
+### `isSelected`
+
+- **Type:** `boolean`
+- **Required:** No
+- **Default:** `false`
+- **Description:** Wether the control is selected or not. This has effect on displaying the "Replace / Remove" buttons. If MediaSelectControl is used within a button render, provide the block's `isSelected` property. If used in the sidebar or settings page simply pass `true`.
+
+### `className`
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** ``
+- **Description:** Additional class name(s) for the control.
+
+### `classNamePreview`
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** ``
+- **Description:** Additional class name(s) for the media preview.
+
+### `getPreview`
+
+- **Type:** `({ media }) => React.Component`
+- **Required:** No
+- **Default:** ``
+- **Description:** Function to override the preview. Media info is provided as an argument.
+- **Usage Example:** `getPreview={({ media }) => <img src={media.url} />}`

--- a/plugin/admin/src/js/components/media-select-control/index.js
+++ b/plugin/admin/src/js/components/media-select-control/index.js
@@ -1,0 +1,162 @@
+import { MediaUpload } from '@wordpress/media-utils';
+import {
+	BaseControl,
+	Button,
+	ButtonGroup,
+	DropZone,
+	ResponsiveWrapper,
+	Spinner,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+
+const MediaSelectControl = ({
+	label = __('Select image', 'lhbasicsp'),
+	labelSet = __('Set image', 'lhbasicsp'),
+	help = '',
+	value,
+	onChange,
+	allowedTypes = ['image'],
+	imageSize = 'full',
+	isSelected,
+	className,
+	classNamePreview = 'lh-preview-image',
+	getPreview,
+}) => {
+	const { editorSettings, media } = useSelect((select) => {
+		const { getMedia } = select('core');
+		const { getSettings } = select('core/block-editor');
+		return {
+			media: value ? getMedia(value) : null,
+			editorSettings: getSettings(),
+		};
+	});
+
+	let mediaWidth, mediaHeight, mediaSourceUrl, mediaTitle;
+	if (media) {
+		const filename = media.source_url.split('/').pop();
+
+		mediaTitle = `${media.title.rendered} (${filename})`;
+		if (media.media_type === 'image') {
+			const { sizes } = media.media_details;
+			const sizeKey = sizes[imageSize] !== undefined ? imageSize : 'full';
+
+			mediaWidth = sizes[sizeKey].width;
+			mediaHeight = sizes[sizeKey].height;
+			mediaSourceUrl = sizes[sizeKey].source_url;
+		} else {
+			// TODO: Better non-image media type previews.
+			mediaWidth = 64;
+			mediaHeight = 64;
+			mediaSourceUrl = `${window.lhagenturSettings.pluginUrl}/img/icons/media--document.svg`;
+		}
+	}
+
+	const onUpdateMedia = ({ id }) => {
+		onChange(id);
+	};
+	const onDropMedia = (filesList) => {
+		editorSettings.mediaUpload({
+			allowedTypes,
+			filesList,
+			onFileChange([{ id }]) {
+				onChange(id);
+			},
+		});
+	};
+	const onRemoveMedia = () => {
+		onChange(0);
+	};
+
+	const hasMedia = !!value && media;
+	const isPreview = !isSelected && hasMedia;
+
+	const getPreviewImage = () =>
+		hasMedia ? (
+			<img
+				src={mediaSourceUrl}
+				alt={mediaTitle}
+				className={classNamePreview}
+				width={mediaWidth}
+				height={mediaHeight}
+			/>
+		) : null;
+
+	if (isPreview) {
+		return <>{getPreview ? getPreview({ media }) : getPreviewImage()}</>;
+	}
+
+	const clsPrefix = 'lh-media-select-control';
+	const controlClassNames = classNames(clsPrefix, 'stack', className);
+
+	return (
+		<BaseControl
+			id={clsPrefix}
+			label={label}
+			help={help}
+			className={controlClassNames}
+		>
+			<MediaUpload
+				title={label}
+				onSelect={onUpdateMedia}
+				allowedTypes={allowedTypes}
+				modalClass={`${clsPrefix}__media-modal`}
+				value={value}
+				render={({ open }) => (
+					<div className={`${clsPrefix}__container`}>
+						<Button
+							className={
+								!value
+									? `${clsPrefix}__toggle`
+									: `${clsPrefix}__preview`
+							}
+							onClick={open}
+							aria-label={__('Edit or update', 'lhbasicsp')}
+							variant={'secondary'}
+						>
+							{!!value && !media && <Spinner />}
+							{!value && <>{labelSet}</>}
+							{hasMedia && (
+								<ResponsiveWrapper>
+									<div className={`${clsPrefix}__preview`}>
+										{getPreview
+											? getPreview({ media })
+											: getPreviewImage()}
+									</div>
+								</ResponsiveWrapper>
+							)}
+						</Button>
+						<DropZone onFilesDrop={onDropMedia} />
+					</div>
+				)}
+			/>
+			{!!value && (
+				<ButtonGroup className={`${clsPrefix}__actions`}>
+					{media && !media.isLoading && (
+						<MediaUpload
+							title={label}
+							onSelect={onUpdateMedia}
+							allowedTypes={allowedTypes}
+							modalClass={`${clsPrefix}__media-modal`}
+							render={({ open }) => (
+								<Button onClick={open} variant="secondary">
+									{__('Replace', 'lhbasicsp')}
+								</Button>
+							)}
+						/>
+					)}
+					<Button
+						onClick={onRemoveMedia}
+						variant="tertiary"
+						isDestructive
+					>
+						{__('Remove', 'lhbasicsp')}
+					</Button>
+				</ButtonGroup>
+			)}
+		</BaseControl>
+	);
+};
+
+export default MediaSelectControl;

--- a/plugin/img/icons/media--document.svg
+++ b/plugin/img/icons/media--document.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 32 32">
+	<path d="m25.7 9.3-7-7c-.2-.2-.4-.3-.7-.3H8c-1.1 0-2 .9-2 2v24c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V10c0-.3-.1-.5-.3-.7zM18 4.4l5.6 5.6H18V4.4zM24 28H8V4h8v6c0 1.1.9 2 2 2h6v16z"/>
+	<path d="M10 22h12v2H10zM10 16h12v2H10z"/>
+</svg>


### PR DESCRIPTION
This PR creates a MediaSelectComponent and exposes it via `lhbasics.components.MediaSelectControl` 

See the [README](asdf) (`/plugin/src/js/componenty/media-select-control/Readme.md`) for further info + reasoning.



## How to test:

- edit `/plugin/inc/Settings/Settings.php` and add `wp_enqueue_media();` before the enqueue call of `lhagentur-settings-page`. Also add `lhbasics-blocks-helper` as dependency for the `lhagentur-settings-page` script
- edit `/plugin/src/js/modules/settings-page.js` and add the components via `window.lhbasics.components`
- - add a media state `const [mediaTest, setMediaTest] = useState(null);`
- - add the component somewhere:
```JSX
<MediaSelectControl
	value={mediaTest}
	onChange={setMediaTest}
	isSelected={true}
/>```
