### PR TITLE
Add/components/weblink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "lh-basics-plugin-project",
       "version": "0.3.5",
       "license": "GPLv2",
+      "dependencies": {
+        "@wordpress/icons": "^10.19.0"
+      },
       "devDependencies": {
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-react": "^7.26.3",
@@ -1947,7 +1950,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
       "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -4696,15 +4698,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
-      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -5471,6 +5487,60 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/@wordpress/element": {
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.19.0.tgz",
+      "integrity": "sha512-11kWRNiHbDkm5uXxEQiVVcEmdUHzBUjzsgp7Ui1iT8yDp0Taf8F30GzqGlWiu0B1K9VxUYLgVCqXamNqo64Ahg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@types/react": "^18.2.79",
+        "@types/react-dom": "^18.2.25",
+        "@wordpress/escape-html": "^3.19.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@wordpress/element/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@wordpress/env": {
       "version": "10.19.0",
       "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.19.0.tgz",
@@ -5493,6 +5563,19 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.19.0.tgz",
+      "integrity": "sha512-vG2h1e/+MmLupGzseeoveB+48wz+ZhB9FhJ+yl0B19H/n4PfcSBl3XD0EPw9iAM6y6KMST/2qqkdFGNwohdnmA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -5597,6 +5680,52 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@wordpress/icons": {
+      "version": "10.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.19.0.tgz",
+      "integrity": "sha512-bYIzWgK3pLI/ShAzkhtzesy/f77WdC7CUdY6kbyic6Q706E3NOqHPeEyvecyOXJn9LKjwtes9jcnjOehNIyuxw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.19.0",
+        "@wordpress/primitives": "^4.19.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/icons/node_modules/@wordpress/primitives": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.19.0.tgz",
+      "integrity": "sha512-HX7lvE6R/u3iJI8sbf85/7k3Vasdco4EWmwT1JTWpRVMl1KcphfmaYs7/nTDqrkbOo19VHOZQhnJCjUPd/O5QA==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@babel/runtime": "7.25.7",
+        "@wordpress/element": "^6.19.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/icons/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -6780,6 +6909,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -6827,6 +6966,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -6849,6 +6999,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/chardet": {
@@ -7017,6 +7187,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7162,6 +7341,17 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "node_modules/continuable-cache": {
@@ -7699,7 +7889,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -8022,7 +8211,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -10127,6 +10315,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "license": "MIT",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -10788,7 +10986,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11069,7 +11266,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11536,7 +11732,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -11549,7 +11744,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -11821,7 +12015,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -12245,6 +12438,16 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12275,6 +12478,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -14498,7 +14721,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/regenerator-transform": {
@@ -15040,6 +15262,17 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -15272,7 +15505,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -16461,7 +16693,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -16732,6 +16963,24 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
     "webpack-cli": "^6.0.1",
     "webpack-livereload-plugin": "^3.0.2",
     "webpack-remove-empty-scripts": "^1.0.4"
+  },
+  "dependencies": {
+    "@wordpress/icons": "^10.19.0"
   }
 }

--- a/plugin-test/admin/src/js/script.js
+++ b/plugin-test/admin/src/js/script.js
@@ -10,6 +10,7 @@ const {
 	PostSelectControl,
 	TaxonomySelectControl,
 	MediaSelectControl,
+	WeblinkSetting,
 } = window.lhbasics.components;
 
 function slotFillTest(Component) {
@@ -22,6 +23,13 @@ function slotFillTest(Component) {
 			page: null,
 			tags: null,
 		});
+		const [weblink, setWeblink] = useState({
+			title: '',
+			url: '',
+			opensInNewTab: false,
+			id: null, // Not needed in non-persistent state, but added for demonstration.
+		});
+
 		const { apiSettings, setApiSettings } = props;
 
 		return (
@@ -90,6 +98,11 @@ function slotFillTest(Component) {
 								isSelected={true}
 							/>
 						</div>
+						<WeblinkSetting
+							label={'Weblink Setting'}
+							value={weblink}
+							onChange={setWeblink}
+						/>
 					</SettingsPanel>
 				</MainSettings>
 			</>

--- a/plugin-test/blocks/demo/block.json
+++ b/plugin-test/blocks/demo/block.json
@@ -19,6 +19,14 @@
     },
     "postSingle": {
       "type": "number"
+    },
+    "link": {
+      "type": "object",
+      "default": {
+        "url": "",
+        "title": "",
+        "opensInNewTab": false
+      }
     }
   },
   "example": {},

--- a/plugin-test/blocks/demo/edit.js
+++ b/plugin-test/blocks/demo/edit.js
@@ -1,15 +1,20 @@
 /**
  * WordPress dependencies.
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { PanelBody } from '@wordpress/components';
-const { IconSelectControl } = window.lhbasics.components;
+const { IconSelectControl, WeblinkControl, WeblinkToolbarButton } =
+	window.lhbasics.components;
 
 const Edit = (props) => {
 	const { attributes, setAttributes } = props;
 
-	const { icon } = attributes;
+	const { icon, link } = attributes;
 
 	return (
 		<>
@@ -23,8 +28,19 @@ const Edit = (props) => {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			<BlockControls>
+				<WeblinkToolbarButton
+					value={link}
+					onChange={(value) => setAttributes({ link: value })}
+				/>
+			</BlockControls>
 			<div {...useBlockProps()}>
 				<p>{__('This is a demo block.', 'lhpbpp')}</p>
+				<WeblinkControl
+					label={__('Demo block link', 'lhpbpp')}
+					value={link}
+					onChange={(value) => setAttributes({ link: value })}
+				/>
 			</div>
 		</>
 	);

--- a/plugin/admin/src/css/components.css
+++ b/plugin/admin/src/css/components.css
@@ -1,3 +1,4 @@
 @import "components/entity-select-control.css";
 @import "components/icon-select-control.css";
 @import "components/media-select-control.css";
+@import "components/weblink-control.css";

--- a/plugin/admin/src/css/components/media-select-control.css
+++ b/plugin/admin/src/css/components/media-select-control.css
@@ -15,6 +15,13 @@
 		margin-bottom: calc(8px);
 		padding: 0;
 	}
+
+	&.is-selected {
+
+		& .lh-media-select-control__preview {
+			background-color: #f0f0f1;
+		}
+	}
 }
 
 .lh-media-select-control__container {

--- a/plugin/admin/src/css/components/weblink-control.css
+++ b/plugin/admin/src/css/components/weblink-control.css
@@ -1,0 +1,217 @@
+/* Control */
+.lh-weblink-control__tools {
+	display: block;
+}
+
+.lh-weblink-control__dropdown-content {
+
+	& .components-popover__content {
+		overflow-y: initial;
+		min-width: 18rem;
+	}
+}
+
+.lh-weblink-control__preview {
+	display: grid;
+
+	grid-template-columns: 1fr;
+	grid-template-rows: 1fr;
+
+	grid-template-areas:
+		"title"
+		"url";
+
+	grid-column-gap: 0.5rem;
+	grid-row-gap: 0.25rem;
+
+	text-decoration: none !important;
+
+	max-width: 100%;
+
+	&.lh-has-icon {
+		grid-template-columns: 30px 1fr;
+		grid-template-rows: auto 1fr;
+
+		grid-template-areas:
+			"icon title"
+			"icon url";
+	}
+
+	& .lh-weblink-control__preview-icon {
+		grid-area: icon;
+		color: #333;
+		align-self: start;
+		width: 30px;
+		height: auto;
+	}
+
+	& .lh-weblink-control__preview-title {
+		grid-area: title;
+		font-weight: 700;
+	}
+
+	& .lh-weblink-control__preview-url {
+		grid-area: url;
+		font-size: 0.8em;
+		color: #333;
+		word-break: break-all;
+	}
+}
+
+.lh-weblink-control {
+	margin-bottom: 1rem;
+}
+
+.lh-weblink-control__label {
+	display: block;
+	font-weight: 700;
+	flex: 0 0 100%;
+	margin-bottom: 0.25rem;
+}
+
+/** Weblinks Control */
+.lh-weblinks-control {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-template-rows: 1fr;
+	grid-row-gap: 1rem;
+
+	& .lh-weblinks-control__weblink {
+		display: grid;
+		grid-template-columns: auto max-content;
+
+		& .lh-weblinks-control__actions {
+			opacity: 0.1;
+			transition: opacity 0.2s ease-in-out;
+
+			& .components-button {
+				color: #999;
+				text-decoration: none;
+
+				&:hover {
+					color: var(--wp-admin-theme-color);
+				}
+			}
+		}
+
+		&:hover .lh-weblinks-control__actions {
+			opacity: 1;
+		}
+	}
+
+	& .lh-weblinks-control__options {
+		display: flex;
+		justify-content: flex-end;
+
+		& .components-button {
+			color: #999;
+			text-decoration: none;
+
+			&:hover {
+				color: var(--wp-admin-theme-color);
+			}
+		}
+	}
+}
+
+/* Setting */
+
+/* LABEL */
+.lh-weblink-setting__label {
+	display: block;
+	font-weight: 700;
+	flex: 0 0 100%;
+	margin-bottom: 0.25rem;
+}
+
+/* PREVIEW */
+.lh-weblink-setting__preview {
+	display: grid;
+
+	grid-template-columns: 1fr;
+	grid-template-rows: 1fr;
+
+	grid-template-areas:
+		"title"
+		"url";
+
+	grid-column-gap: 0.5rem;
+	grid-row-gap: 0.25rem;
+
+	text-decoration: none !important;
+
+	max-width: 100%;
+
+	&.lh-has-icon {
+		grid-template-columns: 30px 1fr;
+		grid-template-rows: auto 1fr;
+
+		grid-template-areas:
+			"icon title"
+			"icon url";
+	}
+}
+
+.lh-weblink-setting__preview-icon {
+	grid-area: icon;
+	color: #333;
+	align-self: start;
+	width: 30px;
+	height: auto;
+}
+
+.lh-weblink-setting__preview-title {
+	grid-area: title;
+	font-weight: 700;
+}
+
+.lh-weblink-setting__preview-url {
+	grid-area: url;
+	font-size: 0.8em;
+	color: #333;
+	word-break: break-all;
+}
+
+/* POPOVER */
+.lh-weblink-setting__popover {
+
+	& .components-popover__content {
+		width: 20rem;
+	}
+
+	& .lh-weblink-setting__select__control {
+		border-radius: 2px;
+		border-color: #949494;
+	}
+
+	& .lh-weblink-setting__select__indicator-separator {
+		background-color: #949494;
+	}
+
+	& .lh-weblink-setting__select__indicator {
+		color: #949494;
+	}
+
+	& .lh-weblink-setting__select + * {
+		margin-top: 0.5rem;
+	}
+
+	& .lh-weblink-setting__select__input {
+		box-shadow: none !important;
+		border: 1px solid transparent; /* Makes the input 32px high, just like <TextControl /> */
+	}
+
+	& .lh-weblink-setting__select__value-container,
+	& .lh-weblink-setting__select__input-container {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+}
+
+/* FOOTER */
+.lh-weblink-setting__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: 1rem;
+}

--- a/plugin/admin/src/js/blocks-helper.js
+++ b/plugin/admin/src/js/blocks-helper.js
@@ -13,18 +13,28 @@ import EntitySelectControl, {
 	PostSelectControl,
 	TaxonomySelectControl,
 } from './components/entity-select-control';
+import WeblinkControl from './components/weblink-control';
+import WeblinkSetting from './components/weblink-control/setting';
+import WeblinkToolbarButton from './components/weblink-control/toolbar-button';
 
 window.lhbasics = window.lhbasics || {};
 window.lhbasics.components = window.lhbasics.components || {};
 
 // Register the IconSelectControl component to the global lhbasics.components namespace
 window.lhbasics.components.IconSelectControl = IconSelectControl;
-window.lhbasics.components.EntitySelectControl = EntitySelectControl;
-window.lhbasics.components.PostSelectControl = PostSelectControl;
-window.lhbasics.components.TaxonomySelectControl = TaxonomySelectControl;
 
 // Register the LHIcon component to the global lhbasics.components namespace
 window.lhbasics.components.LHIcon = LHIcon;
 
+// Register the EntitySelectControl component to the global lhbasics.components namespace
+window.lhbasics.components.EntitySelectControl = EntitySelectControl;
+window.lhbasics.components.PostSelectControl = PostSelectControl;
+window.lhbasics.components.TaxonomySelectControl = TaxonomySelectControl;
+
 // Register the MediaSelectControl component to the global lhbasics.components namespace
 window.lhbasics.components.MediaSelectControl = MediaSelectControl;
+
+// Register the WeblinkControl component to the global lhbasics.components namespace
+window.lhbasics.components.WeblinkControl = WeblinkControl;
+window.lhbasics.components.WeblinkSetting = WeblinkSetting;
+window.lhbasics.components.WeblinkToolbarButton = WeblinkToolbarButton;

--- a/plugin/admin/src/js/components/weblink-control/Readme.md
+++ b/plugin/admin/src/js/components/weblink-control/Readme.md
@@ -1,0 +1,189 @@
+# Weblink Components
+
+The Weblink Components offer simple controls for link objects.
+
+## WeblinkControl (Main-)Component
+
+The main component `<WeblinkControl />` should be used with blocks, only.
+
+### Link Object Schema
+
+The (default) link object schema to use with the `<WeblinkControl />`.
+
+```json
+{
+	"url": "",
+	"title": "",
+	"opensInNewTab": false,
+}
+```
+
+### Example Usage
+
+```jsx
+import { useState } from '@wordpress/element';
+import WeblinkControl from 'path/to/WeblinkControl';
+
+const MyWeblinkControl = () => {
+	const [link, setLink] = useState({ url: '', link: '', opensInNewTab: false });
+
+	return (
+		<WeblinkControl
+			label="A block's link"
+			value={link}
+			onChange={setLink}
+		/>
+	);
+};
+
+export default MyWeblinkControl;
+```
+
+### Props
+
+#### `label`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `''`
+- **Description:** The text label displayed above the control.
+
+#### `value`
+
+- **Type:** `object`
+- **Required:** No
+- **Description:** The link object to control.
+
+#### `onChange`
+
+- **Type:** `(value: object) => void`
+- **Required:** Yes
+- **Description:** Callback function invoked when the link object changes. It receives the new link object.
+
+#### `subjectName`
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** `'weblink'`
+- **Description:** The subject name of the link.
+
+## WeblinkToolbarButton Component
+
+The component `<WeblinkToolbarButton />` should be used with blocks, only.
+
+### Link Object Schema
+
+The (default) link object schema to use with the `<WeblinkToolbarButton />`.
+
+```json
+{
+	"url": "",
+	"title": "",
+	"opensInNewTab": false,
+}
+```
+
+### Example Usage
+
+```jsx
+import { BlockControls } from `@wordpress/block-editor`;
+import { useState } from '@wordpress/element';
+import WeblinkToolbarButton from 'path/to/WeblinkToolbarButton';
+
+const MyWeblinkControl = () => {
+	const [link, setLink] = useState({ url: '', link: '', opensInNewTab: false });
+
+	return (
+		<BlockControls>
+			<WeblinkToolbarButton
+				value={link}
+				onChange={setLink}
+			/>
+		</BlockControls>
+	);
+};
+
+export default MyWeblinkControl;
+```
+
+### Props
+
+#### `value`
+
+- **Type:** `object`
+- **Required:** No
+- **Description:** The link object to control.
+
+#### `onChange`
+
+- **Type:** `(value: object) => void`
+- **Required:** Yes
+- **Description:** Callback function invoked when the link object changes. It receives the new link object.
+
+## WeblinkSetting Component
+
+The component `<WeblinkSetting />` should be used outside of block-editor context elements like blocks (e.g. at LH Settings).
+
+### Link Object Schema
+
+The (default) link object schema to use with the `<WeblinkSetting />`.
+Note: This component __does not__ utilize the `@wordpress/block-editor`.`<LinkControl />` because of the block-editor data context not working properly with just that component and its dependencies.
+Note2: The `id` is mandatory here for a more straight forward approach to hold info if a link is internal or external.
+
+```json
+{
+	"id": 0,
+	"url": "",
+	"title": "",
+	"opensInNewTab": false,
+}
+```
+
+### Example Usage
+
+```jsx
+import { useState } from '@wordpress/element';
+import WeblinkSetting from 'path/to/WeblinkSetting';
+
+const MyWeblinkSetting = () => {
+	const [link, setLink] = useState({ id: 0, url: '', link: '', opensInNewTab: false });
+
+	return (
+		<WeblinkSetting
+			label="A block's link"
+			value={link}
+			onChange={setLink}
+		/>
+	);
+};
+
+export default MyWeblinkSetting;
+```
+
+### Props
+
+#### `label`
+
+- **Type:** `string | ReactNode`
+- **Required:** No
+- **Default:** `''`
+- **Description:** The text label displayed above the control.
+
+#### `value`
+
+- **Type:** `object`
+- **Required:** No
+- **Description:** The link object to control.
+
+#### `onChange`
+
+- **Type:** `(value: object) => void`
+- **Required:** Yes
+- **Description:** Callback function invoked when the link object changes. It receives the new link object.
+
+#### `subjectName`
+
+- **Type:** `string`
+- **Required:** No
+- **Default:** `'weblink'`
+- **Description:** The subject name of the link.

--- a/plugin/admin/src/js/components/weblink-control/index.js
+++ b/plugin/admin/src/js/components/weblink-control/index.js
@@ -1,0 +1,118 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+/**
+ * A control to select a weblink, which consits of a URL, a label and an icon.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Dropdown, Button, PanelRow, TextControl } from '@wordpress/components';
+import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
+
+/**
+ * External dependencies.
+ */
+import classNames from 'classnames';
+
+export default function WeblinkControl({
+	label,
+	value,
+	onChange,
+	subjectName,
+	extraControls,
+}) {
+	const [popoverAnchor, setPopoverAnchor] = useState();
+	if (value === undefined || value === null) {
+		value = {};
+	}
+
+	if (subjectName === undefined) {
+		subjectName = __('weblink', 'lhbasicsp');
+	}
+
+	const controlId = `lh-weblink-control--${subjectName
+		.replace(' ', '')
+		.toLowerCase()}`;
+
+	const buttonClassNames = classNames({
+		'lh-weblink-control__preview': true,
+	});
+
+	return (
+		<div className="lh-weblink-control" ref={setPopoverAnchor}>
+			{label && (
+				<label
+					htmlFor={controlId}
+					className="lh-weblink-control__label"
+				>
+					{label}
+				</label>
+			)}
+			<Dropdown
+				id={controlId}
+				contentClassName="lh-weblink-control__dropdown-content"
+				focusOnMount="container"
+				popoverProps={{
+					anchor: popoverAnchor,
+					resize: false,
+				}}
+				renderToggle={({ isOpen, onToggle }) => (
+					<Button
+						variant="link"
+						onClick={onToggle}
+						aria-expanded={isOpen}
+						className={buttonClassNames}
+					>
+						<div className="lh-weblink-control__preview-title">
+							{value.title ||
+								sprintf(
+									/** translators: %s is the name of the subject */
+									__('Edit %s', 'lhbasicsp'),
+									subjectName
+								)}
+						</div>
+						{value.url && (
+							<div className="lh-weblink-control__preview-url">
+								{filterURLForDisplay(
+									safeDecodeURI(value.url),
+									30
+								)}
+							</div>
+						)}
+					</Button>
+				)}
+				renderContent={() => {
+					return (
+						<LinkControl
+							className={'lh-weblink-control__link-control'}
+							value={value}
+							onChange={(newValue) => {
+								onChange({ ...value, ...newValue });
+							}}
+							renderControlBottom={() => (
+								<div className="block-editor-link-control__tools lh-weblink-control__tools">
+									<PanelRow className="panel-row-full-width">
+										<TextControl
+											label={__('Title', 'lhbasicsp')}
+											value={value.title ?? ''}
+											onChange={(newValue) => {
+												onChange({
+													...value,
+													title: newValue,
+												});
+											}}
+										/>
+									</PanelRow>
+									{extraControls}
+								</div>
+							)}
+						/>
+					);
+				}}
+			/>
+		</div>
+	);
+}

--- a/plugin/admin/src/js/components/weblink-control/setting.js
+++ b/plugin/admin/src/js/components/weblink-control/setting.js
@@ -1,0 +1,197 @@
+/**
+ * A setting to select a weblink, which consits of a URL, a label and an icon.
+ *
+ * This component is different to the WeblinkControl as the WLC only works,
+ * within a block-editor context, while the *Setting component is intended to be used
+ * in a settings page.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Dropdown,
+	Button,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';
+
+/**
+ * External dependencies.
+ */
+import AsyncSelect from 'react-select/async';
+
+/**
+ * Constants.
+ */
+const CLS_BASE = 'lh-weblink-setting';
+const REST_SEARCH_PATH = `/wp/v2/search`;
+const DEFAULT_OPTIONS = [
+	{
+		id: 0,
+		title: __('External URL', 'kbsp'),
+	},
+];
+
+export default function WeblinkSetting({
+	label,
+	value,
+	onChange,
+	subjectName,
+	extraControls,
+}) {
+	const [popoverAnchor, setPopoverAnchor] = useState();
+	const [selectedPost, setSelectedPost] = useState(null);
+
+	if (value === undefined || value === null) {
+		value = {};
+	}
+
+	if (subjectName === undefined) {
+		subjectName = __('weblink', 'kbsp');
+	}
+
+	const controlId = `${CLS_BASE}--${subjectName
+		.replace(' ', '')
+		.toLowerCase()}`;
+
+	const loadOptions = async (query) => {
+		const searchUrl = `${REST_SEARCH_PATH}?search=${query}`;
+		try {
+			const data = await apiFetch({ path: searchUrl });
+			if (query.startsWith('http')) {
+				return [...data, ...DEFAULT_OPTIONS];
+			}
+			return data;
+		} catch (err) {
+			return [];
+		}
+	};
+
+	useEffect(() => {
+		if (value?.id > 0 && !selectedPost) {
+			apiFetch({ path: `${REST_SEARCH_PATH}?include=${value.id}` }).then(
+				(data) => {
+					setSelectedPost(data);
+				}
+			);
+		}
+	}, [value, selectedPost]);
+
+	const isExternalUrl = value?.id === 0;
+
+	return (
+		<div className={CLS_BASE} ref={setPopoverAnchor}>
+			{label && (
+				<label htmlFor={controlId} className={`${CLS_BASE}__label`}>
+					{label}
+				</label>
+			)}
+			<Dropdown
+				id={controlId}
+				contentClassName={`${CLS_BASE}__dropdown-content`}
+				focusOnMount={'container'}
+				popoverProps={{
+					anchor: popoverAnchor,
+					className: `${CLS_BASE}__popover`,
+				}}
+				renderToggle={({ isOpen, onToggle }) => (
+					<Button
+						variant="link"
+						onClick={onToggle}
+						aria-expanded={isOpen}
+						className={`${CLS_BASE}__preview`}
+					>
+						<div className={`${CLS_BASE}__preview-title`}>
+							{value.title ||
+								sprintf(
+									/** translators: %s is the name of the subject */
+									__('Edit %s', 'kbsp'),
+									subjectName
+								)}
+						</div>
+						{value.url && (
+							<div className={`${CLS_BASE}__preview-url`}>
+								{filterURLForDisplay(
+									safeDecodeURI(value.url),
+									30
+								)}
+							</div>
+						)}
+					</Button>
+				)}
+				renderContent={({ onClose }) => {
+					return (
+						<>
+							<AsyncSelect
+								label={__('Search for a post / page', 'kbsp')}
+								className={`${CLS_BASE}__select`}
+								classNamePrefix={`${CLS_BASE}__select`}
+								isClearable
+								getOptionLabel={(option) => option.title}
+								getOptionValue={(option) => option.id}
+								defaultValue={selectedPost}
+								// defaultOptions={DEFAULT_OPTIONS}
+								loadOptions={loadOptions}
+								onChange={(selectedItem) => {
+									onChange({
+										...value,
+										id: selectedItem?.id || 0,
+										title: selectedItem?.title || '',
+										url: selectedItem?.url || '',
+									});
+								}}
+							/>
+							<TextControl
+								label={__('Title', 'kbsp')}
+								value={value.title ?? ''}
+								onChange={(newValue) => {
+									onChange({
+										...value,
+										title: newValue,
+									});
+								}}
+							/>
+							{isExternalUrl && (
+								<TextControl
+									label={__('URL', 'kbsp')}
+									value={value.url ?? ''}
+									onChange={(newValue) => {
+										onChange({
+											...value,
+											id: 0, // Editing the URL invalidates "internal link".
+											url: newValue,
+										});
+									}}
+								/>
+							)}
+							<ToggleControl
+								label={__('Open in new tab', 'kbsp')}
+								checked={value?.opensInNewTab ?? false}
+								onChange={() => {
+									onChange({
+										...value,
+										opensInNewTab: !value.opensInNewTab,
+									});
+								}}
+							/>
+							{extraControls}
+							<div className={`${CLS_BASE}__footer`}>
+								<Button variant={'primary'} onClick={onClose}>
+									{__('Apply', 'kbsp')}
+								</Button>
+								<Button variant={'link'} onClick={onClose}>
+									{__('Cancel', 'kbsp')}
+								</Button>
+							</div>
+						</>
+					);
+				}}
+			/>
+		</div>
+	);
+}

--- a/plugin/admin/src/js/components/weblink-control/toolbar-button.js
+++ b/plugin/admin/src/js/components/weblink-control/toolbar-button.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies.
+ */
+import {
+	__experimentalLinkControl as LinkControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/block-editor';
+import { Popover, ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Assets.
+ */
+import { link as linkIcon, linkOff as linkOffIcon } from '@wordpress/icons';
+
+export default function WeblinkToolbarButton({ value, onChange, onRemove }) {
+	const [popoverAnchor, setPopoverAnchor] = useState();
+	const [isOpen, setIsOpen] = useState(false);
+
+	const hasURL = value?.url !== undefined && value?.url !== '';
+
+	const handleOnRemove = () => {
+		if (onRemove) {
+			onRemove();
+		} else {
+			onChange({
+				url: '',
+				title: value?.title ?? '',
+				opensInNewTab: false,
+			});
+		}
+		setIsOpen(false);
+	};
+	return (
+		<>
+			<ToolbarButton
+				ref={setPopoverAnchor}
+				icon={hasURL ? linkOffIcon : linkIcon}
+				label={
+					hasURL
+						? __('Edit Link', 'lhbasicsp')
+						: __('Add Link', 'lhbasicsp')
+				}
+				onClick={() => setIsOpen(!isOpen)}
+			/>
+			{isOpen && (
+				<Popover anchor={popoverAnchor}>
+					<LinkControl
+						value={value}
+						onChange={onChange}
+						onRemove={handleOnRemove}
+					/>
+				</Popover>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
This PR adds and exposes three new components to control Weblinks:

- `<WeblinkControl />` to be used within blocks and/or block `<InspectorControls />`
- `<WeblinkToolbarButton />` to be used within block's `<BlockControls />`
- `<WeblinkSetting />` to be used with LH // Settings or any other non-block-editor-context

The reasoning for the `<WeblinkSetting />` lays in the dependency-rabbit-hole of the (still experimental) `<LinkControl />` with the `@wordpress/block-editor` package.

Added Readme for all three components.

Also added tests to
- Settings Page
- Demo Block
- - "within the block"
- - as a toolbar button