### PR TITLE
fix: Expose GLightbox as lhGlightbox to window

### DIFF
--- a/plugin/src/js/lightbox.js
+++ b/plugin/src/js/lightbox.js
@@ -1,5 +1,7 @@
 import GLightbox from 'glightbox';
 
+window.lhGlightbox = window?.lhGlightbox ?? GLightbox;
+
 document.addEventListener('DOMContentLoaded', () => {
 	new LightboxControl();
 });


### PR DESCRIPTION
Todo stuff like

```
document.addEventListener('DOMContentLoaded', () => {
	const paragraphs = document.querySelectorAll('p');
	const elements = [];
	paragraphs.forEach((paragraph) => {
		elements.push({
			content: paragraph.innerHTML,
		});
	});
	const lb = window.lhGlightbox({ elements });
	lb.open();
});
```

On projects utilizing lh basics plugin.
This makes allready loaded lightbox code reusable instead of bundling own versions