### PR TITLE
fix: Make WP7.0 ready

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2191,7 +2190,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2215,7 +2213,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2330,7 +2327,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2791,7 +2787,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3449,7 +3444,6 @@
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4700,7 +4694,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4845,7 +4838,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4906,7 +4898,6 @@
       "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -4929,7 +4920,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5036,7 +5026,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -5491,7 +5480,6 @@
       "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -5750,7 +5738,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6040,7 +6027,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6077,7 +6063,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6981,7 +6966,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -7877,7 +7861,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8826,7 +8809,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8883,7 +8865,6 @@
       "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -12937,7 +12918,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14034,7 +14014,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15542,7 +15521,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/schema-utils": {
       "version": "4.3.2",
@@ -15570,7 +15550,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16314,7 +16293,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -16596,7 +16574,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17444,7 +17421,6 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17494,7 +17470,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/plugin-test/blocks/demo/edit.js
+++ b/plugin-test/blocks/demo/edit.js
@@ -7,7 +7,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, TextControl } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 const { IconSelectControl, WeblinkControl, WeblinkToolbarButton } =
 	window.lhbasics.components;
 
@@ -21,11 +21,6 @@ const Edit = (props) => {
 			<InspectorControls>
 				<PanelBody title={__('Settings', 'lhpbpp')}>
 					<p>{__('This is a demo block.', 'lhpbpp')}</p>
-					<TextControl
-						label={__('Demo block text', 'lhpbpp')}
-						value={attributes.text || ''}
-						onChange={(value) => setAttributes({ text: value })}
-					/>
 					<IconSelectControl
 						label={__('Select an icon', 'lhpbpp')}
 						value={icon}

--- a/plugin-test/blocks/demo/edit.js
+++ b/plugin-test/blocks/demo/edit.js
@@ -7,7 +7,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, TextControl } from '@wordpress/components';
 const { IconSelectControl, WeblinkControl, WeblinkToolbarButton } =
 	window.lhbasics.components;
 
@@ -21,6 +21,11 @@ const Edit = (props) => {
 			<InspectorControls>
 				<PanelBody title={__('Settings', 'lhpbpp')}>
 					<p>{__('This is a demo block.', 'lhpbpp')}</p>
+					<TextControl
+						label={__('Demo block text', 'lhpbpp')}
+						value={attributes.text || ''}
+						onChange={(value) => setAttributes({ text: value })}
+					/>
 					<IconSelectControl
 						label={__('Select an icon', 'lhpbpp')}
 						value={icon}

--- a/plugin/admin/src/css/components/icon-select-control.css
+++ b/plugin/admin/src/css/components/icon-select-control.css
@@ -8,6 +8,11 @@
 	& input[type="text"]:focus {
 		box-shadow: none;
 	}
+
+	& .react-select__control {
+		border-radius: 2px;
+		border: 1px solid var(--wp-components-color-gray-600, #949494);
+	}
 }
 
 .lh-icon-select-option-label {

--- a/plugin/admin/src/css/components/weblink-control.css
+++ b/plugin/admin/src/css/components/weblink-control.css
@@ -1,13 +1,32 @@
 /* Control */
 .lh-weblink-control__tools {
 	display: block;
+
+	& .components-base-control {
+		width: 100%;
+	}
 }
 
 .lh-weblink-control__dropdown-content {
 
+	& .block-editor-link-control__field {
+		margin: 0;
+	}
+
 	& .components-popover__content {
 		overflow-y: initial;
 		min-width: 18rem;
+	}
+
+	& .block-editor-link-control__preview {
+		padding: 0;
+	}
+
+	& .block-editor-link-control {
+
+		& > * {
+			margin: 12px;
+		}
 	}
 }
 

--- a/plugin/admin/src/js/components/icon-select-control/index.js
+++ b/plugin/admin/src/js/components/icon-select-control/index.js
@@ -189,6 +189,8 @@ const IconSelectControl = ({
 						<span>{option.label}</span>
 					</div>
 				)}
+				// Debug
+				// menuIsOpen={true}
 			/>
 		</BaseControl>
 	);

--- a/plugin/admin/src/js/components/weblink-control/index.js
+++ b/plugin/admin/src/js/components/weblink-control/index.js
@@ -93,7 +93,7 @@ export default function WeblinkControl({
 								onChange({ ...value, ...newValue });
 							}}
 							renderControlBottom={() => (
-								<div className="block-editor-link-control__tools lh-weblink-control__tools">
+								<div className="lh-weblink-control__tools">
 									<PanelRow className="panel-row-full-width">
 										<TextControl
 											label={__('Title', 'lhbasicsp')}

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -10,7 +10,7 @@ import {
 dispatch(coreStore).addEntities([
 	{
 		label: 'Icons',
-		name: 'icon',
+		name: 'lhicon',
 		kind: 'root',
 		baseURL: '/lhbasics/v1/icons',
 		key: 'slug',
@@ -51,13 +51,14 @@ export const useIcons = (params = {}) => {
 			? must_include.length
 			: per_page;
 
-	const { records: icons, ...states } = useEntityRecords('root', 'icon', {
+	const { records: icons, ...states } = useEntityRecords('root', 'lhicon', {
 		search,
 		page,
 		per_page: effectivePerPage,
 		must_include: processedMustInclude,
 		...query,
 	});
+
 	return { icons, ...states };
 };
 

--- a/plugin/admin/src/js/data/entities/icon.js
+++ b/plugin/admin/src/js/data/entities/icon.js
@@ -69,6 +69,6 @@ export const useIcons = (params = {}) => {
  * @return {Object} An object containing the icon (as `record`) and other state properties.
  */
 export const useIcon = (slug) => {
-	const { record: icon, ...states } = useEntityRecord('root', 'icon', slug);
+	const { record: icon, ...states } = useEntityRecord('root', 'lhicon', slug);
 	return { icon, ...states };
 };

--- a/plugin/lhbasicsp.php
+++ b/plugin/lhbasicsp.php
@@ -9,7 +9,9 @@
  * Description: A plugin that provides basic functionality for our WordPress projects.
  * Author: Luehrsen // Heinrich
  * Author URI: https://www.luehrsen-heinrich.de
- * Version: 0.4.0
+ * x-release-please-start-version
+ * Version: 0.4.3
+ * x-release-please-end
  * Text Domain: lhbasicsp
  * Domain Path: /languages
  */


### PR DESCRIPTION
This PR fixes all LHIcon and IconSelectControl related issues since WP 7.0

- core registeres it's own `icon` store since WP 7.0 so I renamed ours to `lhicon`
- tweaked some styles of the icon select to fit the core's component styles
- tweaked the weblink control styles to have proper spacings at the popover