### PR TITLE
feat: add application passwords module

### DIFF
--- a/docs/public-apis.md
+++ b/docs/public-apis.md
@@ -60,6 +60,7 @@ The result can be overridden with:
 
 Built-in module slugs:
 
+- `application_passwords`
 - `disable_comments`
 - `gravity_forms`
 - `lazysizes`

--- a/plugin/inc/Application_Passwords/Application_Passwords.php
+++ b/plugin/inc/Application_Passwords/Application_Passwords.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Holds the Application_Passwords class.
+ *
+ * @package lhbasicsp
+ */
+
+namespace WpMunich\basics\plugin\Application_Passwords;
+
+use WpMunich\basics\plugin\Plugin_Component;
+use WpMunich\basics\plugin\Settings\Settings;
+
+/**
+ * Enables WordPress application passwords when the module is active.
+ */
+class Application_Passwords extends Plugin_Component {
+
+	public const MODULE = 'application_passwords';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_actions() {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function add_filters() {
+		add_filter( 'wp_is_application_passwords_available', '__return_true', 20 );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function must_run() {
+		add_filter( 'lhagentur_available_modules', array( $this, 'add_module' ) );
+	}
+
+	/**
+	 * Add the module definition.
+	 *
+	 * @param array $modules The available modules.
+	 * @return array The modified modules.
+	 */
+	public function add_module( $modules ) {
+		$modules[] = array(
+			'title'       => __( 'Application Passwords', 'lhbasicsp' ),
+			'description' => __( 'Enables WordPress application passwords and overrides earlier filters that disable them.', 'lhbasicsp' ),
+			'slug'        => self::MODULE,
+		);
+
+		return $modules;
+	}
+
+	/**
+	 * Whether the application passwords module is active.
+	 *
+	 * @return bool Whether the module is active.
+	 */
+	protected function is_active() {
+		return $this->container()->get( Settings::class )->is_module_active( self::MODULE );
+	}
+}

--- a/plugin/inc/Plugin.php
+++ b/plugin/inc/Plugin.php
@@ -19,22 +19,24 @@ class Plugin {
 	/**
 	 * Constructor.
 	 *
-	 * @param Blocks\Blocks                     $blocks           The blocks component.
-	 * @param i18n\I18N                         $i18n             The i18n component.
-	 * @param Disable_Comments\Disable_Comments $disable_comments The disable comments component.
-	 * @param Gravity_Forms\Gravity_Forms       $gravity_forms    The gravity forms component.
-	 * @param Lazysizes\Lazysizes               $lazysizes        The lazysizes component.
-	 * @param Lightbox\Lightbox                 $lightbox         The lightbox component.
-	 * @param Settings\Settings                 $settings         The settings component.
-	 * @param Admin_UX\Admin_UX                 $admin_ux         The admin UX component.
-	 * @param Performance\Performance           $performance      The performance component.
-	 * @param Styles\Styles                     $styles           The styles component.
-	 * @param SVG\SVG                           $svg              The svg component.
-	 * @param Logging\Logs                      $logs             The logs component.
+	 * @param Blocks\Blocks                               $blocks           The blocks component.
+	 * @param i18n\I18N                                   $i18n             The i18n component.
+	 * @param Application_Passwords\Application_Passwords $application_passwords The application passwords component.
+	 * @param Disable_Comments\Disable_Comments           $disable_comments The disable comments component.
+	 * @param Gravity_Forms\Gravity_Forms                 $gravity_forms    The gravity forms component.
+	 * @param Lazysizes\Lazysizes                         $lazysizes        The lazysizes component.
+	 * @param Lightbox\Lightbox                           $lightbox         The lightbox component.
+	 * @param Settings\Settings                           $settings         The settings component.
+	 * @param Admin_UX\Admin_UX                           $admin_ux         The admin UX component.
+	 * @param Performance\Performance                     $performance      The performance component.
+	 * @param Styles\Styles                               $styles           The styles component.
+	 * @param SVG\SVG                                     $svg              The svg component.
+	 * @param Logging\Logs                                $logs             The logs component.
 	 */
 	public function __construct(
 		private Blocks\Blocks $blocks,
 		private i18n\I18N $i18n,
+		private Application_Passwords\Application_Passwords $application_passwords,
 		private Disable_Comments\Disable_Comments $disable_comments,
 		private Gravity_Forms\Gravity_Forms $gravity_forms,
 		private Lazysizes\Lazysizes $lazysizes,

--- a/plugin/tests/Test_Application_Passwords.php
+++ b/plugin/tests/Test_Application_Passwords.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Tests for the application passwords module.
+ *
+ * @package lhbasicsp
+ */
+
+use WpMunich\basics\plugin\Application_Passwords\Application_Passwords;
+
+/**
+ * Test the application passwords module.
+ */
+class Test_Application_Passwords extends WP_UnitTestCase {
+	/**
+	 * Component created by the current test.
+	 *
+	 * @var Application_Passwords|null
+	 */
+	private $component = null;
+
+	/**
+	 * Prepare a clean module and filter state.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		update_option( 'active_modules', array() );
+		remove_filter( 'wp_is_application_passwords_available', '__return_false', 10 );
+		remove_filter( 'wp_is_application_passwords_available', '__return_true', 20 );
+	}
+
+	/**
+	 * Restore the filter state after each test.
+	 */
+	public function tear_down() {
+		if ( null !== $this->component ) {
+			remove_filter( 'lhagentur_available_modules', array( $this->component, 'add_module' ) );
+		}
+
+		remove_filter( 'wp_is_application_passwords_available', '__return_false', 10 );
+		remove_filter( 'wp_is_application_passwords_available', '__return_true', 20 );
+		update_option( 'active_modules', array() );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the module is offered in the settings module list.
+	 */
+	public function test_module_is_available() {
+		$modules = apply_filters( 'lhagentur_available_modules', array() );
+		$modules = wp_list_filter( $modules, array( 'slug' => Application_Passwords::MODULE ) );
+
+		$this->assertCount( 1, $modules );
+	}
+
+	/**
+	 * Test that an inactive module does not override application password availability.
+	 */
+	public function test_inactive_module_does_not_register_override() {
+		$this->component = new Application_Passwords();
+
+		$this->assertFalse( has_filter( 'wp_is_application_passwords_available', '__return_true' ) );
+
+		add_filter( 'wp_is_application_passwords_available', '__return_false', 10 );
+
+		$this->assertFalse( apply_filters( 'wp_is_application_passwords_available', true ) );
+	}
+
+	/**
+	 * Test that the active module overrides Patchstack's equivalent filter.
+	 */
+	public function test_active_module_overrides_earlier_filter() {
+		update_option( 'active_modules', array( Application_Passwords::MODULE ) );
+		add_filter( 'wp_is_application_passwords_available', '__return_false', 10 );
+
+		$this->component = new Application_Passwords();
+
+		$this->assertSame( 20, has_filter( 'wp_is_application_passwords_available', '__return_true' ) );
+		$this->assertTrue( apply_filters( 'wp_is_application_passwords_available', true ) );
+	}
+}


### PR DESCRIPTION
## Summary
- add an opt-in Application Passwords settings module
- override earlier availability filters at priority 20 without changing Patchstack options
- document the built-in module slug and cover active/inactive behavior

## Testing
- npm test
- direct wp-env integration check: override-ok
- npm run test:unit:env:plugin starts, but all tests fail before assertions because the existing WordPress test base calls PHPUnit\\Util\\Test::parseTestMethodAnnotations(), which is unavailable in PHPUnit 10

## Dependency
- stacked on #484 because that PR introduces docs/public-apis.md and the current plugin architecture used here