### PR TITLE
fix: replace-block-editor-link-control

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "release:dependencies": "composer install --working-dir=plugin --no-dev --optimize-autoloader && composer run --working-dir=plugin prefix-dependencies",
     "release:package": "node ./bin/archiveProject.js",
     "release": "npm run release:build && npm run release:version && npm run release:dependencies && npm run release:package",
-    "prestart": "npm install && composer install && composer run --working-dir=plugin prefix-dependencies && composer install --working-dir=plugin && npm run build",
+    "prestart": "npm install && composer install && composer install --working-dir=plugin && composer run --working-dir=plugin prefix-dependencies && npm run build",
     "start": "npx wp-env start",
     "stop": "npx wp-env stop",
     "watch": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "release:dependencies": "composer install --working-dir=plugin --no-dev --optimize-autoloader && composer run --working-dir=plugin prefix-dependencies",
     "release:package": "node ./bin/archiveProject.js",
     "release": "npm run release:build && npm run release:version && npm run release:dependencies && npm run release:package",
-    "prestart": "npm install && composer install && npm run build",
+    "prestart": "npm install && composer install && composer run --working-dir=plugin prefix-dependencies && composer install --working-dir=plugin && npm run build",
     "start": "npx wp-env start",
     "stop": "npx wp-env stop",
     "watch": "webpack --watch",

--- a/plugin-test/inc/Blocks/Blocks.php
+++ b/plugin-test/inc/Blocks/Blocks.php
@@ -88,8 +88,8 @@ class Blocks extends Plugin_Component {
 
 		wp_enqueue_style(
 			'basicsTestp-admin-components',
-			plugin()->get_plugin_url() . '/admin/dist/css/components.min.css',
-			array(),
+			plugin()->get_plugin_url() . 'admin/dist/css/components.min.css',
+			array( 'lhbasicsp-admin-components' ),
 			plugin()->get_plugin_version(),
 			'all'
 		);

--- a/plugin/admin/src/css/components.css
+++ b/plugin/admin/src/css/components.css
@@ -1,6 +1,6 @@
-@import "components/_react-select-control.css";
-@import "components/entity-select-control.css";
-@import "components/icon-select-control.css";
-@import "components/media-select-control.css";
-@import "components/tiny-mce.css";
-@import "components/weblink-control.css";
+@import "./components/_react-select-control.css";
+@import "./components/entity-select-control.css";
+@import "./components/icon-select-control.css";
+@import "./components/media-select-control.css";
+@import "./components/tiny-mce.css";
+@import "./components/weblink-control.css";

--- a/plugin/admin/src/css/components/weblink-control.css
+++ b/plugin/admin/src/css/components/weblink-control.css
@@ -1,6 +1,9 @@
 /* Control */
 .lh-weblink-control__tools {
 	display: block;
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
+	padding-bottom: 0.25rem;
 
 	& .components-base-control {
 		width: 100%;

--- a/plugin/admin/src/js/components/weblink-control/index.js
+++ b/plugin/admin/src/js/components/weblink-control/index.js
@@ -7,7 +7,7 @@
  * WordPress dependencies.
  */
 import { Dropdown, Button, PanelRow, TextControl } from '@wordpress/components';
-import { __experimentalLinkControl as LinkControl } from '@wordpress/block-editor';
+import { LinkControl } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { filterURLForDisplay, safeDecodeURI } from '@wordpress/url';

--- a/plugin/admin/src/js/components/weblink-control/toolbar-button.js
+++ b/plugin/admin/src/js/components/weblink-control/toolbar-button.js
@@ -57,10 +57,10 @@ export default function WeblinkToolbarButton({ value, onChange, onRemove }) {
 								<PanelRow className="panel-row-full-width">
 									<TextControl
 										label={__('Title', 'lhbasicsp')}
-										value={value.title ?? ''}
+										value={value?.title ?? ''}
 										onChange={(newValue) => {
 											onChange({
-												...value,
+												...(value ?? {}),
 												title: newValue,
 											});
 										}}

--- a/plugin/admin/src/js/components/weblink-control/toolbar-button.js
+++ b/plugin/admin/src/js/components/weblink-control/toolbar-button.js
@@ -1,10 +1,13 @@
 /**
  * WordPress dependencies.
  */
+import { LinkControl } from '@wordpress/block-editor';
 import {
-	__experimentalLinkControl as LinkControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/block-editor';
-import { Popover, ToolbarButton } from '@wordpress/components';
+	PanelRow,
+	Popover,
+	TextControl,
+	ToolbarButton,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
@@ -49,6 +52,22 @@ export default function WeblinkToolbarButton({ value, onChange, onRemove }) {
 						value={value}
 						onChange={onChange}
 						onRemove={handleOnRemove}
+						renderControlBottom={() => (
+							<div className="lh-weblink-control__tools">
+								<PanelRow className="panel-row-full-width">
+									<TextControl
+										label={__('Title', 'lhbasicsp')}
+										value={value.title ?? ''}
+										onChange={(newValue) => {
+											onChange({
+												...value,
+												title: newValue,
+											});
+										}}
+									/>
+								</PanelRow>
+							</div>
+						)}
 					/>
 				</Popover>
 			)}

--- a/plugin/inc/Blocks/Blocks.php
+++ b/plugin/inc/Blocks/Blocks.php
@@ -57,14 +57,14 @@ class Blocks extends Plugin_Component {
 		$blocks_helper_assets = $assets['js/blocks-helper.min.js'] ?? array();
 		wp_register_script(
 			'lhbasics-blocks-helper',
-			plugin()->get_plugin_url() . '/admin/dist/js/blocks-helper.min.js',
+			plugin()->get_plugin_url() . 'admin/dist/js/blocks-helper.min.js',
 			array_merge( array( 'lhbasics' ), $blocks_helper_assets['dependencies'], $blocks_helper_extra_assets ),
 			$blocks_helper_assets['version'],
 			true
 		);
 		wp_register_style(
 			'lhbasicsp-admin-components',
-			plugin()->get_plugin_url() . '/admin/dist/css/components.min.css',
+			plugin()->get_plugin_url() . 'admin/dist/css/components.min.css',
 			array( 'wp-components' ),
 			plugin()->get_plugin_version(),
 			'all'

--- a/plugin/inc/Settings/Settings.php
+++ b/plugin/inc/Settings/Settings.php
@@ -21,6 +21,7 @@ class Settings extends Plugin_Component {
 	protected function add_actions() {
 		add_action( 'admin_menu', array( $this, 'add_options_pages' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'init', array( $this, 'register_assets' ), 1 );
 		add_action( 'init', array( $this, 'register_settings' ) );
 	}
 
@@ -56,11 +57,11 @@ class Settings extends Plugin_Component {
 	}
 
 	/**
-	 * Enqueue assets.
+	 * Register shared admin assets.
 	 *
 	 * @return void
 	 */
-	public function enqueue_assets() {
+	public function register_assets() {
 		$assets = wp_json_file_decode(
 			plugin()->get_plugin_path() . '/admin/dist/assets.json',
 			array( 'associative' => true )
@@ -73,6 +74,18 @@ class Settings extends Plugin_Component {
 			$lhbasics_assets['dependencies'],
 			$lhbasics_assets['version'],
 			true
+		);
+	}
+
+	/**
+	 * Enqueue assets.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets() {
+		$assets = wp_json_file_decode(
+			plugin()->get_plugin_path() . '/admin/dist/assets.json',
+			array( 'associative' => true )
 		);
 
 		if ( $this->is_lh_settings_page() ) {

--- a/plugin/tests/Test_LHBasicp.php
+++ b/plugin/tests/Test_LHBasicp.php
@@ -37,4 +37,12 @@ class Test_LHBasicp extends WP_UnitTestCase {
 			has_action( 'wp_enqueue_scripts', array( $lightbox, 'enqueue_scripts' ) )
 		);
 	}
+
+	/**
+	 * Shared admin script dependencies are registered during init.
+	 */
+	public function test_shared_admin_scripts_are_registered_on_init() {
+		$this->assertTrue( wp_script_is( 'lhbasics', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'lhbasics-blocks-helper', 'registered' ) );
+	}
 }


### PR DESCRIPTION
__experimentalLinkControl is deprecated, use blockEditor.LinkControl instead
fix title input in toolbar weblink control